### PR TITLE
Increase default DAG timeout.

### DIFF
--- a/populus/chain.py
+++ b/populus/chain.py
@@ -714,7 +714,10 @@ class BaseGethChain(Chain):
         self.stack.enter_context(self.geth)
 
         if self.geth.is_mining:
-            self.geth.wait_for_dag(600)
+            # On Amazon EC2 2 VCPU small unit you get 32% of DAG generated
+            # within 600 seconds. Estimate is
+            # we can generate whole DAG in 40 minutes.
+            self.geth.wait_for_dag(60*40)
         if self.geth.ipc_enabled:
             self.geth.wait_for_ipc(60)
         if self.geth.rpc_enabled:


### PR DESCRIPTION
### What was wrong?

The default DAG timeout was too low for CI/Amazon EC2 environment.
### How was it fixed?

Build an estimation using Amazon EC2 t2.small unit.
#### Cute Animal Picture

![put a cute animal picture here](http://www.cutestpaw.com/wp-content/uploads/2012/08/Shes-a-cuddly-sleeper-just-like-me.jpg)
