### PR TITLE
Feat/solc options

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -13,7 +13,7 @@ In addition to a local project configuration file, populus supports a *global*
 configuration file which should be located in your user's ``$HOME`` directory.
 Local project configuration will always supercede global configuration.
 
-.. code-block::
+.. code-block:: ini
 
     [populus]
     # project level configuration values would be set here.
@@ -170,7 +170,7 @@ Each chain allows configuration via the following options.
 Here is an example configuration file.
 
 
-.. code-block::
+.. code-block:: ini
 
     [populus]
     default_chain=morden
@@ -187,3 +187,28 @@ Here is an example configuration file.
     [chain:local_test]
     provider=web3.providers.ipc.IPCProvider
     ipc_path=/some/other/path/geth.ipc
+
+Solidity compiler options
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Solidity compiler options are in ``[solc]`` sections of the configuration file.
+These options allow you to fine tune the smart contract compilation proces.
+
+* ``remappings``:
+
+    This option allows you to specify Solidity import path remappings. You can use
+    optional `{project_dir}` substitution.
+    `More information about this Solidity feature <http://solidity.readthedocs.io/en/develop/layout-of-source-files.html#paths>`_.
+
+
+.. code-block:: ini
+
+    # Define where Zeppelin project (https://github.com/OpenZeppelin/zeppelin-solidity/)
+    # contracts are located
+    [solc]
+    remappings =
+        zeppelin={project_dir}/zeppelin
+
+
+For low level information compiler options,
+see :py:func:`populus.compilation.parse_solc_options_from_config`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -212,3 +212,40 @@ These options allow you to fine tune the smart contract compilation proces.
 
 For low level information compiler options,
 see :py:func:`populus.compilation.parse_solc_options_from_config`.
+
+Configuring project for tests
+-----------------------------
+
+py.test tests do not read ``populus.ini`` configuration file.
+
+py.test tests run with a ``project`` fixture that is used by ``chain`` fixture.
+If you want to customize ``project``, e.g. to override compiler options,
+you can do it as following.
+
+.. code-block:: python
+
+    import os
+
+    import pytest
+
+    from populus.plugin import create_project
+    from populus.utils.config import Config
+
+
+    @pytest.fixture(scope="module")
+    def project(request):
+        """Create a Populus project to run tests with custom import remappings."""
+        config = Config()
+        config.add_section("solc")
+
+        # Set path mapping for Zeppelin sol files
+        remappings = "zeppelin=" + os.path.join(os.path.abspath(os.getcwd()), "zeppelin")
+        config.set("solc", "remappings", remappings)
+        return create_project(request, config)
+
+
+    def test_create_contract(chain):
+        milestones = chain.get_contract('TestableMilestonePriced')
+        assert milestones.call().getMilestonesCount() == 0
+        assert milestones.call().milestonesSealed == False
+

--- a/populus/cli/compile_cmd.py
+++ b/populus/cli/compile_cmd.py
@@ -51,9 +51,5 @@ def compile_contracts(ctx, watch, optimize):
     compile_project_contracts(project, **solc_options)
 
     if watch:
-        thread = gevent.spawn(
-            watch_project_contracts,
-            project=project,
-            **solc_options,
-        )
+        thread = gevent.spawn(watch_project_contracts, project=project, **solc_options)
         thread.join()

--- a/populus/cli/compile_cmd.py
+++ b/populus/cli/compile_cmd.py
@@ -1,3 +1,5 @@
+import os
+
 import gevent
 
 import click
@@ -40,7 +42,7 @@ def compile_contracts(ctx, watch, optimize):
     project = ctx.obj['PROJECT']
 
     substitutions = {
-        "project_dir": project.project_dir
+        "project_dir": os.path.abspath(project.project_dir)
     }
 
     solc_options = parse_solc_options_from_config(project.config, substitutions)

--- a/populus/cli/compile_cmd.py
+++ b/populus/cli/compile_cmd.py
@@ -7,6 +7,8 @@ from populus.utils.cli import (
     watch_project_contracts,
 )
 
+from populus.compilation import parse_solc_options_from_config
+
 from .main import main
 
 
@@ -37,12 +39,15 @@ def compile_contracts(ctx, watch, optimize):
     """
     project = ctx.obj['PROJECT']
 
-    compile_project_contracts(project, optimize=True)
+    solc_options = parse_solc_options_from_config(project.config)
+    solc_options["optimize"] = optimize
+
+    compile_project_contracts(project, **solc_options)
 
     if watch:
         thread = gevent.spawn(
             watch_project_contracts,
             project=project,
-            optimize=True,
+            **solc_options,
         )
         thread.join()

--- a/populus/cli/compile_cmd.py
+++ b/populus/cli/compile_cmd.py
@@ -39,7 +39,11 @@ def compile_contracts(ctx, watch, optimize):
     """
     project = ctx.obj['PROJECT']
 
-    solc_options = parse_solc_options_from_config(project.config)
+    substitutions = {
+        "project_dir": project.project_dir
+    }
+
+    solc_options = parse_solc_options_from_config(project.config, substitutions)
     solc_options["optimize"] = optimize
 
     compile_project_contracts(project, **solc_options)

--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -14,19 +14,32 @@ from solc.exceptions import (
 )
 
 
-def parse_solc_options_from_config(config):
-    """Get [solc] option section parsed out.
+def parse_solc_options_from_config(config, substitutions, section_name="solc"):
+    """Parse out [solc] config section.
 
     :param config: py:class:`populus.config.Config` instance.
+
+    :param substitutions: Dictionary of variable substitutions in path.
+        Example ``{"project_dir": "/foobar"}
+
+    :param section_name: Alternative solc config section name
 
     :return: dict of kwargs options to be passed to :py:func:`solc.wrapper.solc_wrapper`
     """
 
+    if not config.has_section("solc"):
+        # No special solc options given
+        return {}
+
     options = {}
 
-    remappings = config.get("solc", "remappings", None)
+    remappings = config.get(section_name, "remappings")
     if remappings:
-        import pdb ; pdb.set_trace()
+        remappings = remappings.split()
+        remappings = [r.strip().format(**substitutions) for r in remappings if r.strip()]
+        options["remappings"] = remappings
+
+    return options
 
 
 def find_project_contracts(project_dir, contracts_rel_dir=DEFAULT_CONTRACTS_DIR):

--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -14,6 +14,21 @@ from solc.exceptions import (
 )
 
 
+def parse_solc_options_from_config(config):
+    """Get [solc] option section parsed out.
+
+    :param config: py:class:`populus.config.Config` instance.
+
+    :return: dict of kwargs options to be passed to :py:func:`solc.wrapper.solc_wrapper`
+    """
+
+    options = {}
+
+    remappings = config.get("solc", "remappings", None)
+    if remappings:
+        import pdb ; pdb.set_trace()
+
+
 def find_project_contracts(project_dir, contracts_rel_dir=DEFAULT_CONTRACTS_DIR):
     contracts_dir = os.path.join(project_dir, contracts_rel_dir)
 

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -9,20 +9,32 @@ CACHE_KEY_MTIME = "populus/project/compiled_contracts_mtime"
 CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
 
 
-@pytest.fixture(scope="session")
-def project(request):
-    # This should probably be configurable using the `request` fixture but it's
-    # unclear what needs to be configurable.
+def create_project(request, config=None):
+    """py.test helper to create a Populus project to run.
 
+    Caches compild contracts per run.
+
+    :param config: :py:class:`populus.config.Config` instance
+
+    :return: :py:class:`populus.project.Project`
+    """
     # use pytest cache to preset the sessions project to recently compiled contracts
     contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
     mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
     project = Project()
+    project.config = config
     project.fill_contracts_cache(contracts, mtime)
     request.config.cache.set(CACHE_KEY_CONTRACTS, project.compiled_contracts)
     request.config.cache.set(CACHE_KEY_MTIME, project.get_source_modification_time())
 
     return project
+
+
+@pytest.fixture(scope="session")
+def project(request):
+    # This should probably be configurable using the `request` fixture but it's
+    # unclear what needs to be configurable.
+    return create_project(request, None)
 
 
 @pytest.yield_fixture()

--- a/populus/project.py
+++ b/populus/project.py
@@ -174,7 +174,7 @@ class Project(object):
         :return: dict of kwargs options to be passed to :py:func:`solc.wrapper.solc_wrapper`
         """
         substitutions = {
-            "project_dir": self.project_dir,
+            "project_dir": os.path.abspath(self.project_dir),  # solc wants absolute path
         }
         return parse_solc_options_from_config(self.config, substitutions)
 
@@ -187,6 +187,7 @@ class Project(object):
             # somehow.
 
             options = self.solc_options
+
             if not "optimize" in options:
                 options["optimize"] = True
 

--- a/populus/project.py
+++ b/populus/project.py
@@ -35,6 +35,7 @@ from populus.migrations.loading import (
 from populus.compilation import (
     find_project_contracts,
     compile_project_contracts,
+    parse_solc_options_from_config,
 )
 
 from populus.chain import (
@@ -165,15 +166,34 @@ class Project(object):
         self._cached_compiled_contracts = contracts
 
     @property
+    def solc_options(self):
+        """Return Solidity compiler options for this project
+
+        Extract options from solc config section.
+
+        :return: dict of kwargs options to be passed to :py:func:`solc.wrapper.solc_wrapper`
+        """
+        substitutions = {
+            "project_dir": self.project_dir,
+        }
+        return parse_solc_options_from_config(self.config, substitutions)
+
+    @property
     def compiled_contracts(self):
+
         if self.compiled_contracts_stale():
             self._cached_compiled_contracts_mtime = self.get_source_modification_time()
             # TODO: the hard coded `optimize=True` should be configurable
             # somehow.
+
+            options = self.solc_options
+            if not "optimize" in options:
+                options["optimize"] = True
+
             _, self._cached_compiled_contracts = compile_project_contracts(
                 project_dir=self.project_dir,
                 contracts_dir=self.contracts_dir,
-                optimize=True,
+                **options,
             )
         return self._cached_compiled_contracts
 

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -461,14 +461,14 @@ def get_unlocked_deploy_from_address(chain):
     return account
 
 
-def compile_project_contracts(project, optimize=True):
+def compile_project_contracts(project, **solc_options):
     click.echo("============ Compiling ==============")
     click.echo("> Loading source files from: ./{0}\n".format(project.contracts_dir))
 
     result = compile_and_write_contracts(
         project.project_dir,
         project.contracts_dir,
-        optimize=optimize
+        **solc_options
     )
     contract_source_paths, compiled_sources, output_file_path = result
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "pytest>=2.7.2",
         "toposort>=1.4",
         "web3>=2.7.0",
+        "rlp==0.4.6",  # https://github.com/ethereum/pyethereum/issues/421
     ],
     license="MIT",
     zip_safe=False,

--- a/tests/compile/test_solidity_remappings.py
+++ b/tests/compile/test_solidity_remappings.py
@@ -1,0 +1,56 @@
+import pytest
+import textwrap
+import json
+
+import os
+
+from populus.utils.filesystem import DEFAULT_CONTRACTS_DIR
+from populus.compilation import (
+    compile_and_write_contracts,
+)
+
+
+BASE_DIR= os.path.abspath(os.path.dirname(__file__))
+
+project_dir = os.path.join(BASE_DIR, 'projects', 'test-01')
+
+
+CONTRACT_A_SOURCE = textwrap.dedent(("""
+    import "contracts/ContractB.sol";
+    import "contracts/ContractC.sol";
+
+    contract A is C {
+        function A() {
+            B.doit();
+        }
+    }
+"""))
+
+
+CONTRACT_B_SOURCE = textwrap.dedent(("""
+    library B {
+        function doit() {}
+    }
+"""))
+
+
+CONTRACT_C_SOURCE = textwrap.dedent(("""
+    contract C {
+        function C() {}
+    }
+"""))
+
+
+def test_compilation(project_dir, write_project_file):
+    write_project_file('contracts/ContractA.sol', CONTRACT_A_SOURCE)
+    write_project_file('contracts/ContractB.sol', CONTRACT_B_SOURCE)
+    write_project_file('contracts/ContractC.sol', CONTRACT_C_SOURCE)
+
+    source_paths, compiled_sources, outfile_path = compile_and_write_contracts(project_dir, DEFAULT_CONTRACTS_DIR)
+
+    with open(outfile_path) as outfile:
+        compiled_contract_data = json.load(outfile)
+
+    assert 'A' in compiled_contract_data
+    assert 'B' in compiled_contract_data
+    assert 'C' in compiled_contract_data


### PR DESCRIPTION
### What was wrong?

One could not pass remapping options to underlying solc, making it hard to use third party contract code.

### How was it fixed?

Created INI section `[solc]` that can host this option and other options in the future.

NOTE! I could not get Travis tests to run, but managed to run tests locally under Py 3.5. I suggest you run tests locally before merging.

#### Cute Animal Picture

```
                               (__)
 *_                     *_     ( oo             *_
   \      (__)            \    /\/                \  (__)
    \.----( oo____         \.-/----._____          \.( oo___\____
     ||____\/____ \         ||__________ \          |_\/________ \
     OO          `OO        OO          `OO         OO          `OO
 
                     Cow-vette Cow-vertible  (of cowrse)
 
```
