### PR TITLE
bugfix registrar path

### DIFF
--- a/populus/contracts/backends/filesystem.py
+++ b/populus/contracts/backends/filesystem.py
@@ -90,7 +90,12 @@ class JSONFileBackend(BaseContractBackend):
     #
     @property
     def registrar_path(self):
-        return self.config.get('file_path', './registrar.json')
+        file_path = self.config.get('file_path', './registrar.json')
+        project_dir = self.chain.project.project_dir
+        if os.path.dirname(os.path.abspath(file_path)) == project_dir:
+            return file_path
+        else:
+            return os.path.join(project_dir, file_path)
 
     @property
     def registrar_data(self):


### PR DESCRIPTION
### What was wrong?
registrar config 'file_path' allows both relative and absolute path, but if a relative is used, can't run it from a directory that is not the project dir

### How was it fixed?
join the project dir. 
Caveat: user will not be able to point to a registrar outside the project dir, but I think it's safer

#### Cute Animal Picture

![60882193760100490489no](https://user-images.githubusercontent.com/3235489/31758627-e1555eac-b4b6-11e7-8511-55fb1dd3c9b8.jpg)

