### PR TITLE
fix deprecation warnings

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -224,9 +224,9 @@ The following configuration options can be set to control aspects of how
 Populus compiles your project contracts.
 
 
-* ``compilation.contracts_source_dir``
+* ``compilation.contracts_source_dirs``
 
-  Defaults to ``./contracts``.  This sets the root path where populus will
+  Defaults to ``[./contracts]``.  This sets the paths where populus will
   search for contract source files.
 
 * ``compilation.settings.optimize``

--- a/populus/contracts/backends/project.py
+++ b/populus/contracts/backends/project.py
@@ -16,7 +16,7 @@ from .base import (
 class ProjectContractsBackend(BaseContractBackend):
     """
     Provides access to compiled contract assets sources from the project
-    `contracts_source_dir`
+    `contracts_source_dirs`
     """
     is_provider = True
     is_registrar = False

--- a/populus/project.py
+++ b/populus/project.py
@@ -236,19 +236,6 @@ class Project(object):
         return get_compiled_contracts_asset_path(self.build_asset_dir)
 
     @property
-    def contracts_source_dir(self):
-        warnings.warn(DeprecationWarning(
-            "project.contracts_source_dir has been replaced by the plural, "
-            "project.contracts_source_dirs which is an iterable of all source "
-            "directories populus will search for contracts.  Please update your "
-            "code accordingly as this API will be removed in a future release"
-        ))
-        return self.config.get(
-            'compilation.contracts_source_dir',
-            get_contracts_source_dirs(self.project_dir),
-        )[0]
-
-    @property
     @to_tuple
     def contracts_source_dirs(self):
         source_dirs = self.config.get('compilation.contracts_source_dirs')
@@ -266,7 +253,11 @@ class Project(object):
 
     def get_all_source_file_paths(self):
         return tuple(itertools.chain(
-            get_project_source_paths(self.contracts_source_dir),
+            itertools.chain.from_iterable(
+                get_project_source_paths(source_dir)
+                for source_dir
+                in self.contracts_source_dirs
+            ),
             get_test_source_paths(self.tests_dir),
         ))
 

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -1,6 +1,3 @@
-import pytest
-import sys
-
 from populus.project import Project
 
 from populus.utils.chains import (
@@ -18,10 +15,6 @@ from populus.utils.filesystem import (
 
 def test_project_directory_properties(project_dir):
     project = Project(project_dir, create_config_file=True)
-
-    if sys.version_info.major != 2:
-        with pytest.warns(DeprecationWarning):
-            project.contracts_source_dir
 
     contracts_source_dirs = get_contracts_source_dirs(project_dir)
     for left, right in zip(project.contracts_source_dirs, contracts_source_dirs):


### PR DESCRIPTION
### What was wrong?

**LOTS** of deprecation warnings have stacked up.

### How was it fixed?

* Fixed usage of `web3.currentProvider` to use `web3.providers[0]`
* Removed use of `eth_utils.compose`
* Suppressed warning during test run against deprecated functionality.

#### Cute Animal Picture

![dda5d25c36a83f8c6b562fff6aee32fc](https://user-images.githubusercontent.com/824194/33449266-7ff56618-d5c5-11e7-869c-751d2d475297.jpg)
