### PR TITLE
Move source finding to BaseCompilerBackend (Viper phase 1)

### DIFF
--- a/populus/compilation/__init__.py
+++ b/populus/compilation/__init__.py
@@ -5,8 +5,6 @@ import logging
 import os
 
 from populus.utils.compile import (
-    get_project_source_paths,
-    get_test_source_paths,
     validate_compiled_contracts,
     post_process_compiled_contracts,
 )
@@ -24,9 +22,10 @@ def _get_contract_key(contract_data):
 
 def compile_project_contracts(project):
     logger = logging.getLogger('populus.compilation.compile_project_contracts')
+    compiler_backend = project.get_compiler_backend()
 
     project_contract_source_paths = tuple(itertools.chain.from_iterable(
-        get_project_source_paths(source_dir)
+        compiler_backend.get_project_source_paths(source_dir)
         for source_dir
         in project.contracts_source_dirs
     ))
@@ -36,7 +35,7 @@ def compile_project_contracts(project):
         ", ".join(project_contract_source_paths),
     )
 
-    test_contract_source_paths = get_test_source_paths(project.tests_dir)
+    test_contract_source_paths = compiler_backend.get_test_source_paths(project.tests_dir)
     logger.debug(
         "Found %s test source files: %s",
         len(test_contract_source_paths),
@@ -48,7 +47,6 @@ def compile_project_contracts(project):
         test_contract_source_paths,
     ))
 
-    compiler_backend = project.get_compiler_backend()
     base_compiled_contracts = compiler_backend.get_compiled_contracts(
         source_file_paths=all_source_paths,
         import_remappings=project.config.get('compilation.import_remappings'),

--- a/populus/compilation/backends/__init__.py
+++ b/populus/compilation/backends/__init__.py
@@ -7,3 +7,6 @@ from.solc_standard_json import (  # noqa: F401
 from .solc_auto import (  # noqa: F401
     SolcAutoBackend,
 )
+from .viper import (  # noqa: F401
+    ViperBackend,
+)

--- a/populus/compilation/backends/base.py
+++ b/populus/compilation/backends/base.py
@@ -14,8 +14,8 @@ from populus.utils.filesystem import (
 
 class BaseCompilerBackend(object):
     compiler_settings = None
-    project_source_extensions = None
-    test_source_extensions = None
+    project_source_glob = None
+    test_source_glob = None
 
     def __init__(self, settings):
         self.compiler_settings = settings
@@ -25,15 +25,17 @@ class BaseCompilerBackend(object):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @to_tuple
-    def _find_source_files(self, base_dir, extensions):
+    def get_project_source_paths(self, contracts_source_dir):
         return (
             os.path.relpath(source_file_path)
             for source_file_path
-            in recursive_find_files(base_dir, extensions)
+            in recursive_find_files(contracts_source_dir, self.project_source_glob)
         )
 
-    def get_project_source_paths(self, contracts_source_dir):
-        return self._find_source_files(contracts_source_dir, self.project_source_extensions)
-
+    @to_tuple
     def get_test_source_paths(self, tests_dir):
-        return self._find_source_files(tests_dir, self.test_source_extensions)
+        return (
+            os.path.relpath(source_file_path)
+            for source_file_path
+            in recursive_find_files(tests_dir, self.test_source_glob)
+        )

--- a/populus/compilation/backends/base.py
+++ b/populus/compilation/backends/base.py
@@ -1,12 +1,21 @@
 import logging
+import os
 
+from eth_utils import (
+    to_tuple,
+)
 from populus.utils.module_loading import (
     get_import_path,
+)
+from populus.utils.filesystem import (
+    recursive_find_files,
 )
 
 
 class BaseCompilerBackend(object):
     compiler_settings = None
+    project_source_extensions = None
+    test_source_extensions = None
 
     def __init__(self, settings):
         self.compiler_settings = settings
@@ -14,3 +23,17 @@ class BaseCompilerBackend(object):
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         raise NotImplementedError("Must be implemented by subclasses")
+
+    @to_tuple
+    def _find_source_files(self, base_dir, extensions):
+        return (
+            os.path.relpath(source_file_path)
+            for source_file_path
+            in recursive_find_files(base_dir, extensions)
+        )
+
+    def get_project_source_paths(self, contracts_source_dir):
+        return self._find_source_files(contracts_source_dir, self.project_source_extensions)
+
+    def get_test_source_paths(self, tests_dir):
+        return self._find_source_files(tests_dir, self.test_source_extensions)

--- a/populus/compilation/backends/solc_auto.py
+++ b/populus/compilation/backends/solc_auto.py
@@ -40,8 +40,8 @@ def get_solc_backend_class_for_version(solc_version):
 
 
 class SolcAutoBackend(BaseCompilerBackend):
-    project_source_extensions = ('*.sol', )
-    test_source_extensions = ('Test*.sol', )
+    project_source_glob = ('*.sol', )
+    test_source_glob = ('Test*.sol', )
 
     def __init__(self, settings):
         proxy_backend_class = get_solc_backend_class_for_version(get_solc_version())

--- a/populus/compilation/backends/solc_auto.py
+++ b/populus/compilation/backends/solc_auto.py
@@ -40,6 +40,9 @@ def get_solc_backend_class_for_version(solc_version):
 
 
 class SolcAutoBackend(BaseCompilerBackend):
+    project_source_extensions = ('*.sol', )
+    test_source_extensions = ('*.sol', )
+
     def __init__(self, settings):
         proxy_backend_class = get_solc_backend_class_for_version(get_solc_version())
         self.proxy_backend = proxy_backend_class(settings)

--- a/populus/compilation/backends/solc_auto.py
+++ b/populus/compilation/backends/solc_auto.py
@@ -41,7 +41,7 @@ def get_solc_backend_class_for_version(solc_version):
 
 class SolcAutoBackend(BaseCompilerBackend):
     project_source_extensions = ('*.sol', )
-    test_source_extensions = ('*.sol', )
+    test_source_extensions = ('Test*.sol', )
 
     def __init__(self, settings):
         proxy_backend_class = get_solc_backend_class_for_version(get_solc_version())

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -129,6 +129,9 @@ def post_process_compiled_contracts(compiled_contracts):
 
 
 class SolcCombinedJSONBackend(BaseCompilerBackend):
+    project_source_extensions = ('*.sol', )
+    test_source_extensions = ('*.sol', )
+
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('<=0.4.8'):
             raise OSError(

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -130,7 +130,7 @@ def post_process_compiled_contracts(compiled_contracts):
 
 class SolcCombinedJSONBackend(BaseCompilerBackend):
     project_source_extensions = ('*.sol', )
-    test_source_extensions = ('*.sol', )
+    test_source_extensions = ('Test*.sol', )
 
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('<=0.4.8'):

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -129,8 +129,8 @@ def post_process_compiled_contracts(compiled_contracts):
 
 
 class SolcCombinedJSONBackend(BaseCompilerBackend):
-    project_source_extensions = ('*.sol', )
-    test_source_extensions = ('Test*.sol', )
+    project_source_glob = ('*.sol', )
+    test_source_glob = ('Test*.sol', )
 
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('<=0.4.8'):

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -90,7 +90,7 @@ def normalize_compilation_result(compilation_result):
 
 class SolcStandardJSONBackend(BaseCompilerBackend):
     project_source_extensions = ('*.sol', )
-    test_source_extensions = ('*.sol', )
+    test_source_extensions = ('Test*.sol', )
 
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('>=0.4.11'):

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -89,6 +89,9 @@ def normalize_compilation_result(compilation_result):
 
 
 class SolcStandardJSONBackend(BaseCompilerBackend):
+    project_source_extensions = ('*.sol', )
+    test_source_extensions = ('*.sol', )
+
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('>=0.4.11'):
             raise OSError(

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -89,8 +89,8 @@ def normalize_compilation_result(compilation_result):
 
 
 class SolcStandardJSONBackend(BaseCompilerBackend):
-    project_source_extensions = ('*.sol', )
-    test_source_extensions = ('Test*.sol', )
+    project_source_glob = ('*.sol', )
+    test_source_glob = ('Test*.sol', )
 
     def __init__(self, *args, **kwargs):
         if get_solc_version() not in Spec('>=0.4.11'):

--- a/populus/compilation/backends/viper.py
+++ b/populus/compilation/backends/viper.py
@@ -1,0 +1,9 @@
+
+from .base import (
+    BaseCompilerBackend,
+)
+
+
+class ViperBackend(BaseCompilerBackend):
+    project_source_extensions = ('*.v.py', '*.vy')
+    test_source_extensions = ('*.py', )

--- a/populus/compilation/backends/viper.py
+++ b/populus/compilation/backends/viper.py
@@ -1,4 +1,3 @@
-
 from .base import (
     BaseCompilerBackend,
 )

--- a/populus/project.py
+++ b/populus/project.py
@@ -263,9 +263,10 @@ class Project(object):
     _cached_compiled_contracts = None
 
     def get_all_source_file_paths(self):
+        compiler_backend = self.get_compiler_backend()
         return tuple(itertools.chain(
-            get_project_source_paths(self.contracts_source_dir),
-            get_test_source_paths(self.tests_dir),
+            compiler_backend.get_project_source_paths(self.contracts_source_dir),
+            compiler_backend.get_test_source_paths(self.tests_dir),
         ))
 
     def is_compiled_contract_cache_stale(self):

--- a/populus/project.py
+++ b/populus/project.py
@@ -48,8 +48,6 @@ from populus.utils.compile import (
     get_build_asset_dir,
     get_compiled_contracts_asset_path,
     get_contracts_source_dirs,
-    get_project_source_paths,
-    get_test_source_paths,
 )
 
 from populus.utils.filesystem import (

--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -73,25 +73,6 @@ def get_compiled_contracts_asset_path(build_asset_dir):
     return compiled_contracts_asset_path
 
 
-@to_tuple
-def find_solidity_source_files(base_dir):
-    return (
-        os.path.relpath(source_file_path)
-        for source_file_path
-        in recursive_find_files(base_dir, "*.sol")
-    )
-
-
-def get_project_source_paths(contracts_source_dir):
-    project_source_paths = find_solidity_source_files(contracts_source_dir)
-    return project_source_paths
-
-
-def get_test_source_paths(tests_dir):
-    test_source_paths = find_solidity_source_files(tests_dir)
-    return test_source_paths
-
-
 def write_compiled_sources(compiled_contracts_asset_path, compiled_sources):
     logger = logging.getLogger('populus.compilation.write_compiled_sources')
     ensure_file_exists(compiled_contracts_asset_path)

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -94,10 +94,15 @@ def recursive_find_files(base_dir, pattern):
     """
 
     def match(filename, pattern):
-        if isinstance(pattern, tuple):
+        if is_list_like(pattern):
             return any([fnmatch.fnmatch(filename, p) for p in pattern])
-        else:
+        elif is_string(pattern):
             return fnmatch.fnmatch(filename, pattern)
+        else:
+            raise TypeError(
+                "Pattern must either be a string pattern or a list of patterns." +
+                "  Got {0}".format(pattern)
+            )
 
     for dirpath, _, filenames in os.walk(base_dir):
         for filename in filenames:

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -105,24 +105,6 @@ def recursive_find_files(base_dir, pattern):
                 yield os.path.join(dirpath, filename)
 
 
-@to_tuple
-def find_solidity_source_files(base_dir):
-    return (
-        os.path.relpath(source_file_path)
-        for source_file_path
-        in recursive_find_files(base_dir, "*.sol")
-    )
-
-
-@to_tuple
-def find_solidity_test_files(base_dir):
-    return (
-        os.path.relpath(source_file_path)
-        for source_file_path
-        in recursive_find_files(base_dir, "Test*.sol")
-    )
-
-
 @contextlib.contextmanager
 def tempdir(*args, **kwargs):
     directory = _tempfile.mkdtemp(*args, **kwargs)

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -85,9 +85,23 @@ def is_executable_available(program):
 
 @to_tuple
 def recursive_find_files(base_dir, pattern):
+    """
+    Recursively traverse directory tree and find files matching pattern.
+
+    :param base_dir: Base directory to start crawling.
+    :param pattern: File pattern, to match again.
+                    Either string (single pattern match) or tuple (multiple patterns)
+    """
+
+    def match(filename, pattern):
+        if isinstance(pattern, tuple):
+            return any([fnmatch.fnmatch(filename, p) for p in pattern])
+        else:
+            return fnmatch.fnmatch(filename, pattern)
+
     for dirpath, _, filenames in os.walk(base_dir):
         for filename in filenames:
-            if fnmatch.fnmatch(filename, pattern):
+            if match(filename, pattern):
                 yield os.path.join(dirpath, filename)
 
 

--- a/tests/compile-utils/test_find_solidity_source_files.py
+++ b/tests/compile-utils/test_find_solidity_source_files.py
@@ -2,9 +2,6 @@ import itertools
 import os
 
 from populus import Project
-from populus.utils.compile import (
-    find_solidity_source_files,
-)
 from populus.utils.filesystem import (
     is_same_path,
 )
@@ -12,8 +9,9 @@ from populus.utils.filesystem import (
 
 def test_gets_correct_files_default_dir(project_dir, write_project_file):
     project = Project(project_dir, create_config_file=True)
+    compiler_backend = project.get_compiler_backend()
     file_names = tuple(itertools.chain.from_iterable(
-        find_solidity_source_files(source_dir)
+        compiler_backend.get_project_source_paths(source_dir)
         for source_dir
         in project.contracts_source_dirs
     ))

--- a/tests/compile-utils/test_find_viper_source_files.py
+++ b/tests/compile-utils/test_find_viper_source_files.py
@@ -1,0 +1,44 @@
+import itertools
+import os
+
+from populus import Project
+from populus.utils.filesystem import (
+    is_same_path,
+)
+
+
+def test_gets_correct_files_default_dir(project_dir, write_project_file):
+    project = Project(project_dir, create_config_file=True)
+    project.config['compilation']['backend'] = {
+        'class': 'populus.compilation.backends.ViperBackend',
+    }
+
+    compiler_backend = project.get_compiler_backend()
+    file_names = tuple(itertools.chain.from_iterable(
+        compiler_backend.get_project_source_paths(source_dir)
+        for source_dir
+        in project.contracts_source_dirs
+    ))
+
+    should_match = {
+        'contracts/SolidityContract.v.py',
+        'contracts/AnotherFile.vy',
+    }
+
+    should_not_match = {
+        'contracts/Swapfile.v.py.swp',
+        'contracts/Swapfile.v.py.txt',
+        'contracts/BackedUpContract.vy.bak',
+        'contracts/not-contract.vy.txt',
+    }
+
+    for filename in should_match:
+        write_project_file(filename)
+
+    for filename in should_not_match:
+        write_project_file(filename)
+
+    for file_name in file_names:
+        assert os.path.exists(file_name)
+        assert any(is_same_path(file_name, path) for path in should_match)
+        assert not any(is_same_path(file_name, path) for path in should_not_match)


### PR DESCRIPTION
### What was wrong?
 
Populus needs support for Viper! (https://github.com/ethereum/viper) :smile_cat: But to get there we need to make the searching of source files (*.v.py and *.sol) depend on the selected compiler backend.

### How was it fixed?

This is the first step in integrating viper support for populus. It converts find_solidity_source_files functions to be contained on the BaseCompilerBackend instead (this might seem a bit heavy handed but if you check the diff you'll see it makes sense to make finding sources and tests just be dependent on a list of extensions). Additionally I added a stub class  `ViperBackend` to illustrate were I will be placing the rest of the Viper compiler backend code :)

 
#### Cute Animal Picture

![](https://i.pinimg.com/736x/9c/e5/b3/9ce5b37e4bbcd804d1e8af1746b3e1bd--cute-animals-images-puppy-dog-eyes.jpg)
