### PR TITLE
github migration, py2 deprecation, bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 1.11.2
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}.{devnum}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 To start development for Populus you should begin by cloning the repo.
 
 ```bash
-$ git clone git@github.com/pipermerriam/populus.git
+$ git clone git@github.com/ethereum/populus.git
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,79 @@
 # POPULUS
 
-[![Gitter chat](https://badges.gitter.im/pipermerriam/populus.png)](https://gitter.im/pipermerriam/populus "Gitter chat")
-[![Build Status](https://travis-ci.org/pipermerriam/populus.png)](https://travis-ci.org/pipermerriam/populus)
+[![Gitter chat](https://badges.gitter.im/ethereum/populus.png)](https://gitter.im/ethereum/populus "Gitter chat")
+[![Build Status](https://travis-ci.org/ethereum/populus.png)](https://travis-ci.org/ethereum/populus)
 [![Documentation Status](https://readthedocs.org/projects/populus/badge/?version=latest)](https://readthedocs.org/projects/populus/?badge=latest)
 [![PyPi version](https://pypip.in/v/populus/badge.png)](https://pypi.python.org/pypi/populus)
 [![PyPi downloads](https://pypip.in/d/populus/badge.png)](https://pypi.python.org/pypi/populus)
    
 
-Ethereum Development Framework
+Development framework for Ethereum smart contracts
 
+
+## Documentation
 
 [Documentation on ReadTheDocs](http://populus.readthedocs.org/en/latest/)
 
 
-## Features
+## Installation
 
-- compilation
-- deployment
-- testing (using pytest)
-- management of test chains
+```sh
+pip install populus
+```
+
+## Development
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+
+### Running the tests
+
+You can run the tests with:
+
+```sh
+py.test tests
+```
+
+Or you can install `tox` to run the full test suite.
+
+
+### Releasing
+
+Pandoc is required for transforming the markdown README to the proper format to
+render correctly on pypi.
+
+For Debian-like systems:
+
+```
+apt install pandoc
+```
+
+Or on OSX:
+
+```sh
+brew install pandoc
+```
+
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -102,7 +102,7 @@ folder.
 
 * ``stdin`` is `Solidity Input Description as JSON <http://solidity.readthedocs.io/en/develop/using-the-compiler.html?highlight=input%20description#input-description>`_
 
-* ``command_line_options`` are passed to Solidity compiler command line, as given keyword arguments to `py-solc` package's `solc.wrapper.solc_wrapper <https://github.com/pipermerriam/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20>_`
+* ``command_line_options`` are passed to Solidity compiler command line, as given keyword arguments to `py-solc` package's `solc.wrapper.solc_wrapper <https://github.com/ethereum/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20>_`
 
 Contract Source Directory
 """""""""""""""""""""""""
@@ -133,7 +133,7 @@ Settings for the compiler backend
 Configuring compiler for extra
 """"""""""""""""""""""""""""""
 
-Set `solc import path remappings <https://github.com/pipermerriam/py-solc#import-path-remappings>`_. This is especially useful if you want to use libraries like `OpenZeppelin <https://github.com/OpenZeppelin/zeppelin-solidity/>`_ with your project. Then you can directly import Zeppelin contracts like ``import "zeppelin/contracts/token/TransferableToken.sol";``.
+Set `solc import path remappings <https://github.com/ethereum/py-solc#import-path-remappings>`_. This is especially useful if you want to use libraries like `OpenZeppelin <https://github.com/OpenZeppelin/zeppelin-solidity/>`_ with your project. Then you can directly import Zeppelin contracts like ``import "zeppelin/contracts/token/TransferableToken.sol";``.
 
 * key: ``compilation.import_remappings``
 * value: Array of strings

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -371,7 +371,7 @@ You'll have to install solidity, recommended from release 0.4.11 or greater.
 Installation scripts for binary:
 '''''''''''''''''''''''''''''''
 
-    https://github.com/pipermerriam/py-solc#installing-the-solc-binary
+    https://github.com/ethereum/py-solc#installing-the-solc-binary
 
 
 Installation scripts building it:

--- a/populus/__init__.py
+++ b/populus/__init__.py
@@ -3,12 +3,15 @@ import pkg_resources
 import warnings
 import sys
 
+
 if sys.version_info.major < 3:
+    warnings.simplefilter('always', DeprecationWarning)
     warn_msg = ("Python 2 support will end during the first quarter of 2018"
                 "Please upgrade to Python 3"
                 "https://medium.com/@pipermerriam/dropping-python-2-support-d781e7b48160"
                 )
     warnings.warn(warn_msg, DeprecationWarning)
+    warnings.resetwarnings()
 
 
 BASE_DIR = os.path.dirname(__file__)

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -116,7 +116,7 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
         }
 
         # solc command line options as passed to solc_wrapper()
-        # https://github.com/pipermerriam/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20
+        # https://github.com/ethereum/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20
         command_line_options = self.compiler_settings.get("command_line_options", {})
 
         # Get Solidity Input Description settings section

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,32 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-
 from setuptools import setup, find_packages
-
-
-DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-readme = open(os.path.join(DIR, 'README.md')).read()
 
 
 setup(
     name='populus',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version="1.11.2",
     description="""Ethereum Development Framework""",
-    long_description=readme,
+    long_description_markdown_filename='README.md',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
-    url='https://github.com/pipermerriam/populus',
+    url='https://github.com/ethereum/populus',
     include_package_data=True,
     py_modules=['populus'],
+    setup_requires=['setuptools-markdown'],
     install_requires=[
         "anyconfig>=0.7.0",
         "click>=6.6",
         "contextlib2>=0.5.4",
         "eth-testrpc>=1.3.0",
-        "ethereum-utils>=0.2.0",
+        "eth-utils>=0.7.1",
         "jsonschema>=2.5.1",
         "py-geth>=1.9.0",
         "py-solc>=1.2.0",
         "pylru>=1.0.9",
         "pysha3>=0.3,!=1.0,>1.0.0",
-        "pytest>=2.7.2",
+        "pytest>=2.7.2,!=3.3.0",
         "semantic_version>=2.6.0",
         "cytoolz>=0.8.2",
         "toposort>=1.4",


### PR DESCRIPTION
### What was wrong?

Wrong urls due to github migration, pytest issues, and formalize release process.

### How was it fixed?

* Fixed URIs
* exclude broken latest pytest version
* add bumpversion

#### Cute Animal Picture

![1d601ef3cbc991035495d8c701686770](https://user-images.githubusercontent.com/824194/33442631-d5b124c4-d5b2-11e7-9c21-e35f95b1a684.jpg)
