### PR TITLE
Fix deprecation warnings

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -224,9 +224,9 @@ The following configuration options can be set to control aspects of how
 Populus compiles your project contracts.
 
 
-* ``compilation.contracts_source_dir``
+* ``compilation.contracts_source_dirs``
 
-  Defaults to ``./contracts``.  This sets the root path where populus will
+  Defaults to ``[./contracts]``.  This sets the paths where populus will
   search for contract source files.
 
 * ``compilation.settings.optimize``

--- a/populus/chain/tester.py
+++ b/populus/chain/tester.py
@@ -10,7 +10,7 @@ class TesterChain(BaseChain):
 
         self._running = True
 
-        self.rpc_methods = self.web3.currentProvider.rpc_methods
+        self.rpc_methods = self.web3.providers[0].rpc_methods
 
         self.rpc_methods.full_reset()
         self.rpc_methods.rpc_configure('eth_mining', False)

--- a/populus/chain/testrpc.py
+++ b/populus/chain/testrpc.py
@@ -28,7 +28,7 @@ class TestRPCChain(BaseChain):
 
         self._running = True
 
-        self.rpc_methods = self.web3.currentProvider.server.application.rpc_methods
+        self.rpc_methods = self.web3.providers[0].server.application.rpc_methods
 
         self.rpc_methods.full_reset()
         self.rpc_methods.rpc_configure('eth_mining', False)
@@ -43,11 +43,11 @@ class TestRPCChain(BaseChain):
         if not self._running:
             raise ValueError("The TesterChain is not running")
         try:
-            self.web3.currentProvider.server.stop()
-            self.web3.currentProvider.server.close()
-            self.web3.currentProvider.thread.kill()
+            self.web3.providers[0].server.stop()
+            self.web3.providers[0].server.close()
+            self.web3.providers[0].thread.kill()
         except AttributeError:
-            self.web3.currentProvider.server.shutdown()
-            self.web3.currentProvider.server.server_close()
+            self.web3.providers[0].server.shutdown()
+            self.web3.providers[0].server.server_close()
         finally:
             self._running = False

--- a/populus/compilation/backends/base.py
+++ b/populus/compilation/backends/base.py
@@ -25,11 +25,11 @@ class BaseCompilerBackend(object):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @to_tuple
-    def get_project_source_paths(self, contracts_source_dir):
+    def get_project_source_paths(self, source_dir):
         return (
             os.path.relpath(source_file_path)
             for source_file_path
-            in recursive_find_files(contracts_source_dir, self.project_source_glob)
+            in recursive_find_files(source_dir, self.project_source_glob)
         )
 
     @to_tuple

--- a/populus/config/helpers.py
+++ b/populus/config/helpers.py
@@ -4,8 +4,11 @@ import os
 
 import anyconfig
 
-from eth_utils import (
+from cytoolz import (
     compose,
+)
+
+from eth_utils import (
     is_string,
     to_ordered_dict,
 )
@@ -131,8 +134,8 @@ def sort_prioritized_configs(backend_configs, master_config):
 
     return sorted(
         resolved_backend_configs,
-        key=compose(*(
-            operator.itemgetter(1),
+        key=compose(
             operator.itemgetter('priority'),
-        )),
+            operator.itemgetter(1),
+        ),
     )

--- a/populus/contracts/backends/project.py
+++ b/populus/contracts/backends/project.py
@@ -16,7 +16,7 @@ from .base import (
 class ProjectContractsBackend(BaseContractBackend):
     """
     Provides access to compiled contract assets sources from the project
-    `contracts_source_dir`
+    `contracts_source_dirs`
     """
     is_provider = True
     is_registrar = False

--- a/populus/project.py
+++ b/populus/project.py
@@ -234,19 +234,6 @@ class Project(object):
         return get_compiled_contracts_asset_path(self.build_asset_dir)
 
     @property
-    def contracts_source_dir(self):
-        warnings.warn(DeprecationWarning(
-            "project.contracts_source_dir has been replaced by the plural, "
-            "project.contracts_source_dirs which is an iterable of all source "
-            "directories populus will search for contracts.  Please update your "
-            "code accordingly as this API will be removed in a future release"
-        ))
-        return self.config.get(
-            'compilation.contracts_source_dir',
-            get_contracts_source_dirs(self.project_dir),
-        )[0]
-
-    @property
     @to_tuple
     def contracts_source_dirs(self):
         source_dirs = self.config.get('compilation.contracts_source_dirs')

--- a/populus/project.py
+++ b/populus/project.py
@@ -249,12 +249,14 @@ class Project(object):
     _cached_compiled_contracts_mtime = None
     _cached_compiled_contracts = None
 
+    @to_tuple
     def get_all_source_file_paths(self):
         compiler_backend = self.get_compiler_backend()
-        return tuple(itertools.chain(
-            compiler_backend.get_project_source_paths(self.contracts_source_dir),
-            compiler_backend.get_test_source_paths(self.tests_dir),
-        ))
+        return itertools.chain.from_iterable(
+            compiler_backend.get_project_source_paths(source_dir)
+            for source_dir
+            in self.contracts_source_dirs
+        )
 
     def is_compiled_contract_cache_stale(self):
         if self._cached_compiled_contracts is None:

--- a/populus/utils/accounts.py
+++ b/populus/utils/accounts.py
@@ -9,7 +9,7 @@ from web3.providers.tester import (
 
 
 def is_account_locked(web3, account):
-    if isinstance(web3.currentProvider, (EthereumTesterProvider, TestRPCProvider)):
+    if isinstance(web3.providers[0], (EthereumTesterProvider, TestRPCProvider)):
         return not any((is_same_address(account, a) for a in web3.eth.accounts[:10]))
     try:
         web3.eth.sign(account, 'simple-test-data')

--- a/populus/utils/mappings.py
+++ b/populus/utils/mappings.py
@@ -1,8 +1,11 @@
 import operator
 import itertools
 
-from eth_utils import (
+from cytoolz import (
     compose,
+)
+
+from eth_utils import (
     force_text,
     is_dict,
     sort_return,
@@ -22,7 +25,7 @@ def set_nested_key(config, key, value):
     )
     tail_setter = operator.methodcaller('__setitem__', key_tail, value)
 
-    setter_fn = compose(*itertools.chain(head_setters, (tail_setter,)))
+    setter_fn = compose(*reversed(tuple((itertools.chain(head_setters, (tail_setter,))))))
 
     # must write to both the config_for_read and config_for_write
     return setter_fn(config)
@@ -40,7 +43,7 @@ def get_nested_key(config, key):
 
     tail_getter = operator.itemgetter(key_tail)
 
-    getter_fn = compose(*itertools.chain(head_getters, (tail_getter,)))
+    getter_fn = compose(*reversed(tuple(itertools.chain(head_getters, (tail_getter,)))))
 
     try:
         return getter_fn(config)
@@ -65,7 +68,7 @@ def delete_nested_key(config, key):
     )
     tail_deleter = operator.methodcaller('__delitem__', key_tail)
 
-    del_fn = compose(*itertools.chain(head_getters, (tail_deleter,)))
+    del_fn = compose(*reversed(tuple(itertools.chain(head_getters, (tail_deleter,)))))
 
     return del_fn(config)
 
@@ -90,7 +93,7 @@ def pop_nested_key(config, key):
     )
     tail_popper = operator.methodcaller('pop', key_tail)
 
-    popper_fn = compose(*itertools.chain(head_getters, (tail_popper,)))
+    popper_fn = compose(*reversed(tuple(itertools.chain(head_getters, (tail_popper,)))))
 
     return popper_fn(config)
 

--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -83,7 +83,7 @@ def poll_until(poll_fn, success_fn, timeout, poll_interval_fn):
 
 
 def is_tester_web3(web3):
-    return isinstance(web3.currentProvider, (TestRPCProvider, EthereumTesterProvider))
+    return isinstance(web3.providers[0], (TestRPCProvider, EthereumTesterProvider))
 
 
 def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_interval=None):

--- a/tests/chain-management/test_external_chain.py
+++ b/tests/chain-management/test_external_chain.py
@@ -7,4 +7,4 @@ def test_external_chain(project):
     project.config['chains.external.contracts.backends.Memory'] = {'$ref': 'contracts.backends.Memory'}  # noqa: E501
 
     with project.get_chain('external') as external_chain:
-        assert isinstance(external_chain.web3.currentProvider, EthereumTesterProvider)
+        assert isinstance(external_chain.web3.providers[0], EthereumTesterProvider)

--- a/tests/config-objects/test_web3_config_object.py
+++ b/tests/config-objects/test_web3_config_object.py
@@ -72,7 +72,7 @@ def test_getting_web3_instance():
     web3_config = Web3Config({'provider': {'class': 'web3.providers.ipc.IPCProvider'}})
     web3 = web3_config.get_web3()
 
-    assert isinstance(web3.currentProvider, IPCProvider)
+    assert isinstance(web3.providers[0], IPCProvider)
 
 
 def test_default_account_property():

--- a/tests/configuration/test_upgrade_to_user_config.py
+++ b/tests/configuration/test_upgrade_to_user_config.py
@@ -45,6 +45,7 @@ from populus.utils.testing import (
 )
 
 
+@pytest.mark.filterwarnings('ignore:Found legacy config file at')
 @pytest.mark.parametrize(
     'from_legacy_version',
     (V1, V2, V3, V4, V5, V6)
@@ -79,6 +80,7 @@ def test_upgrade_to_user_config(project, from_legacy_version):
     assert upgraded_project.project_config == expected_project_config
 
 
+@pytest.mark.filterwarnings('ignore:Found legacy config file at')
 @user_config_version(FIRST_USER_CONFIG_VERSION)
 def test_upgrade_custom_key(project):
     legacy_config_file_path = get_legacy_json_config_file_path(project_dir=project.project_dir)

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -1,6 +1,3 @@
-import pytest
-import sys
-
 from populus.project import Project
 
 from populus.utils.chains import (
@@ -18,10 +15,6 @@ from populus.utils.filesystem import (
 
 def test_project_directory_properties(project_dir):
     project = Project(project_dir, create_config_file=True)
-
-    if sys.version_info.major != 2:
-        with pytest.warns(DeprecationWarning):
-            project.contracts_source_dir
 
     contracts_source_dirs = get_contracts_source_dirs(project_dir)
     for left, right in zip(project.contracts_source_dirs, contracts_source_dirs):


### PR DESCRIPTION
Replaces #381 

### What was wrong?

**LOTS** of deprecation warnings have stacked up.

### How was it fixed?

* Fixed usage of `web3.currentProvider` to use `web3.providers[0]`
* Removed use of `eth_utils.compose`
* Suppressed warning during test run against deprecated functionality.

#### Cute Animal Picture

![dda5d25c36a83f8c6b562fff6aee32fc](https://user-images.githubusercontent.com/824194/33449266-7ff56618-d5c5-11e7-869c-751d2d475297.jpg)
