### PR TITLE
solc_standard_json: specify compiler outputs explicitly

### DIFF
--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -114,7 +114,16 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
             'language': 'Solidity',
             'sources': sources,
             'settings': {
-                'remappings': import_remappings
+                'remappings': import_remappings,
+                'outputSelection': {
+                    '*': {
+                        '*': [ 'metadata',
+                               'evm.bytecode',
+                               'evm.bytecode.linkReferences',
+                               'evm.deployedBytecode',
+                               'evm.deployedBytecode.linkReferences' ]
+                    }
+                }
             }
         }
 

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -117,11 +117,11 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
                 'remappings': import_remappings,
                 'outputSelection': {
                     '*': {
-                        '*': [ 'metadata',
-                               'evm.bytecode',
-                               'evm.bytecode.linkReferences',
-                               'evm.deployedBytecode',
-                               'evm.deployedBytecode.linkReferences' ]
+                        '*': ['metadata',
+                              'evm.bytecode',
+                              'evm.bytecode.linkReferences',
+                              'evm.deployedBytecode',
+                              'evm.deployedBytecode.linkReferences']
                     }
                 }
             }


### PR DESCRIPTION
Fixes #398 (in a hotfix manner).

### What was wrong?

Solidity compiler v0.4.19 introduced a new setting, `outputSelection`, that - when missing - defaults to "compile and print errors only".

This means that `populus compile` would no longer get the outputs it wanted.

### How was it fixed?

[0.4.19 release notes](https://github.com/ethereum/solidity/releases/tag/v0.4.19) say:

> Standard JSON: Support the `outputSelection` field for selective compilation of target artifacts.

[Docs on which](https://solidity.readthedocs.io/en/develop/using-the-compiler.html#input-description) in turn provide hints on what's missing. (Not linking specific doc version, since there seems to be misconfiguration there - they're not available.)

I'm not sure that this adds in _everything_ that was previously available; or if there's perhaps a simpler way to tell `solc` "do as you did before".

#### Cute Animal Picture

[source](https://www.entrepreneur.com/article/236581) (page 11 for "monkey being difficult" search)

![monkey sitting on railing with ocean in background](https://assets.entrepreneur.com/content/3x2/1300/1408712176-3-eastern-practices-tame-monkey-mind-gibralter-monkey.jpg?width=420)