### PR TITLE
add abi back to output selection

### DIFF
--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -117,11 +117,11 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
                 'remappings': import_remappings,
                 'outputSelection': {
                     '*': {
-                        '*': ['metadata',
-                              'evm.bytecode',
-                              'evm.bytecode.linkReferences',
-                              'evm.deployedBytecode',
-                              'evm.deployedBytecode.linkReferences']
+                        '*': [
+                            'abi',
+                            'metadata',
+                            'evm',
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
fixes #401

### What was wrong?

`abi` was not being included in the output for compilation

### How was it fixed?

Added `abi` back to the output values.

#### Cute Animal Picture

![05286f744fa749b2ce38d07e116b3981](https://user-images.githubusercontent.com/824194/33629011-d03c1f6a-d9bf-11e7-97a0-1b146b018a3a.jpg)
