### PR TITLE
Limited LLL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,8 @@ install:
   - if [ -n "$SOLC_VERSION" ]; then python -m solc.install $SOLC_VERSION; fi
   - if [ -n "$SOLC_VERSION" ]; then export SOLC_BINARY="$SOLC_BASE_INSTALL_PATH/solc-$SOLC_VERSION/bin/solc"; fi
   - if [ -n "$SOLC_VERSION" ]; then export LD_LIBRARY_PATH="$SOLC_BASE_INSTALL_PATH/solc-$SOLC_VERSION/bin"; fi
+  # lllc - installed together with solc
+  - if [ -n "$SOLC_VERSION" ]; then export LLLC_BINARY="$SOLC_BASE_INSTALL_PATH/solc-$SOLC_VERSION/bin/lllc"; fi
   # geth
   - if [ -n "$GETH_VERSION" ]; then travis_retry pip install "py-geth>=1.9.0"; fi
   - if [ -n "$GETH_VERSION" ]; then python -m geth.install $GETH_VERSION; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Contents
     modules
     release
     viper_support
+    lll_support
 
 
 Indices and tables

--- a/docs/lll_support.rst
+++ b/docs/lll_support.rst
@@ -28,8 +28,14 @@ specifying in JSON the on-chain contract's interface.
 Installation
 ------------
 
-On Ubuntu-based systems, ``lllc`` should be available in the same
-package as ``solc``.
+On Ubuntu-based systems, the ``lllc`` compiler seems to no longer
+be available in a package. You might need to `build it from source`_.
+
+For Ubuntu 14.04, one might be shipped together with ``solc``,
+available in ``solidity-ubuntu-trusty.zip`` on the `releases page`_.
+
+
+On Arch Linux, an ``lll`` package is `available in AUR`_.
 
 In general, ``lllc`` should be available in ``PATH``; or an
 ``LLLC_BINARY`` environment variable must be set and pointing to
@@ -42,6 +48,10 @@ To see if it's present:
     $ lllc --version
     LLLC, the Lovely Little Language Compiler
     Version: 0.4.19-develop.2017.12.1+commit.c4cbbb05.Linux.g++
+
+.. _build it from source: https://media.consensys.net/installing-ethereum-compilers-61d701e78f6
+.. _releases page: https://github.com/ethereum/solidity/releases
+.. _available in AUR: https://aur.archlinux.org/packages/lll/
 
 
 Using

--- a/docs/lll_support.rst
+++ b/docs/lll_support.rst
@@ -2,8 +2,8 @@ LLL Support
 ===========
 
 Populus provides partial support for LLL, in particular the
-``lllc`` compiler, currently maintained in tandem
-with Solidity, in the `ethereum/solidity`_ repository.
+``lllc`` compiler, which is currently maintained in tandem
+with Solidity in the `ethereum/solidity`_ repository.
 
 .. _ethereum/solidity: https://github.com/ethereum/solidity
 

--- a/docs/lll_support.rst
+++ b/docs/lll_support.rst
@@ -1,0 +1,100 @@
+LLL Support
+===========
+
+Populus provides partial support for LLL, in particular the
+``lllc`` compiler, currently maintained in tandem
+with Solidity, in the `ethereum/solidity`_ repository.
+
+.. _ethereum/solidity: https://github.com/ethereum/solidity
+
+Known limitations
+-----------------
+
+This feature is highly experimental; mixing different languages,
+e.g. Solidity and LLL or Viper and LLL, is not yet possible.
+
+Since LLL is very low-level, not all language constructs are
+currently supported. In particular, string literals, especially
+defined with the ``lit`` keyword, may be impossible to use.
+
+Finally, LLL programs have no notion of ``web3`` ABI, as detailed
+in the `Ethereum Contract ABI`_ specification. For that reason,
+all ``.lll`` files must have an accompanying ``.lll.abi`` file,
+specifying in JSON the on-chain contract's interface.
+
+.. _Ethereum Contract ABI: https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+
+
+Installation
+------------
+
+On Ubuntu-based systems, ``lllc`` should be available in the same
+package as ``solc``.
+
+In general, ``lllc`` should be available in ``PATH``; or an
+``LLLC_BINARY`` environment variable must be set and pointing to
+the ``lllc`` executable.
+
+To see if it's present:
+
+.. code-block:: shell
+
+    $ lllc --version
+    LLLC, the Lovely Little Language Compiler
+    Version: 0.4.19-develop.2017.12.1+commit.c4cbbb05.Linux.g++
+
+
+Using
+-----
+
+Automatic initialisation of a ``Greeter`` project in LLL with
+``populus --init`` is not yet possible.
+
+This section describes how to do it manually.
+
+Change compilation backend
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The compilation backend must be changed from its default in `project.json`
+by placing a `backend` key in the `compilation` section, as shown below:
+
+.. code-block:: json
+
+    {
+        "version": "7",
+        "compilation": {
+            "contracts_source_dirs": ["./contracts"],
+            "import_remappings": [],
+            "backend": {
+                "class": "populus.compilation.backends.LLLBackend"
+            }
+        }
+    }
+
+Populus will now only compile LLL contracts in the configured ``contracts``
+directories.
+
+Copy LLL-specific Greeter contract and its ABI specification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These files should be available in the `Populus repository`_, as
+`Greeter.lll`_ and `Greeter.lll.abi`_.
+
+Place them in the ``contracts`` directory of your project.
+
+.. _Populus repository: https://github.com/ethereum/populus
+.. _Greeter.lll: https://github.com/ethereum/populus/tree/master/populus/assets
+.. _Greeter.lll.abi: https://github.com/ethereum/populus/tree/master/populus/assets/Greeter.lll.abi
+
+Copy LLL-specific test
+^^^^^^^^^^^^^^^^^^^^^^
+
+This file should be available in the `Populus repository`_, as
+`test_greeter_lll.py`_.
+
+Place it in the ``tests`` directory of your project.
+
+Remove the Solidity/Viper ``test_greeter.py`` if it's still present, so
+``pytest`` doesn't trip.
+
+.. _test_greeter_lll.py: https://github.com/ethereum/populus/tree/master/populus/assets/test_greeter_lll.py

--- a/docs/lll_support.rst
+++ b/docs/lll_support.rst
@@ -3,24 +3,40 @@ LLL Support
 
 Populus provides partial support for LLL, in particular the
 ``lllc`` compiler, which is currently maintained in tandem
-with Solidity in the `ethereum/solidity`_ repository.
+with Solidity and its ``solc`` compiler in the
+`ethereum/solidity`_ repository.
 
 .. _ethereum/solidity: https://github.com/ethereum/solidity
 
 Known limitations
 -----------------
 
-This feature is highly experimental; mixing different languages,
-e.g. Solidity and LLL or Viper and LLL, is not yet possible.
+This feature is highly experimental!
+
+Mixing different languages, e.g. Solidity and LLL or Viper and
+LLL, is not yet possible.
 
 Since LLL is very low-level, not all language constructs are
 currently supported. In particular, string literals, especially
 defined with the ``lit`` keyword, may be impossible to use.
+For example, code using them may compile successfully, but its
+deployment in tests might fail due to Populus' inability to
+determine where in the bytecode the literals have been placed,
+and the ``lllc`` compiler providing no hints to that effect.
 
-Finally, LLL programs have no notion of ``web3`` ABI, as detailed
-in the `Ethereum Contract ABI`_ specification. For that reason,
-all ``.lll`` files must have an accompanying ``.lll.abi`` file,
-specifying in JSON the on-chain contract's interface.
+One-shot contracts that leave the destination account without
+code after running are also not supported, since Populus can't
+differentiate between such use cases and contracts that actually
+failed to deploy.
+
+In fact, the runtime bytecode is extracted from the compiled
+bytecode (as given by ``lllc``) based solely on the signature
+produced by the ``returnlll`` macro.
+
+Finally, LLL programs have no notion of ``web3`` ABI, as it is
+described in the `Ethereum Contract ABI`_ specification. For that
+reason, all ``.lll`` files must have an accompanying ``.lll.abi``
+file, specifying in JSON the contract's interface.
 
 .. _Ethereum Contract ABI: https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
 
@@ -93,7 +109,7 @@ These files should be available in the `Populus repository`_, as
 Place them in the ``contracts`` directory of your project.
 
 .. _Populus repository: https://github.com/ethereum/populus
-.. _Greeter.lll: https://github.com/ethereum/populus/tree/master/populus/assets
+.. _Greeter.lll: https://github.com/ethereum/populus/tree/master/populus/assets/Greeter.lll
 .. _Greeter.lll.abi: https://github.com/ethereum/populus/tree/master/populus/assets/Greeter.lll.abi
 
 Copy LLL-specific test

--- a/populus/assets/Greeter.lll
+++ b/populus/assets/Greeter.lll
@@ -20,7 +20,7 @@
 
   (def '*greet*        0xcfae3217) ; greet()
   (def '*greeting*     0xef690cc0) ; greeting(): public storage in Solidity
-  (def '*set-greeting* 0xb2010978) ; setGreeting(string)
+  (def '*set-greeting* 0xb2010978) ; setGreeting(uint256)
 
   ;; ==========================================================================
   ;; STDLIB

--- a/populus/assets/Greeter.lll
+++ b/populus/assets/Greeter.lll
@@ -1,0 +1,100 @@
+;;;; ==========================================================================
+;;;; @title Lovely Little Greeter
+;;;; @author Noel Maersk <veox>
+
+(seq
+  ;; ==========================================================================
+  ;; MEMORY LAYOUT
+
+  (def '*memloc-function-selector* 0x20)
+
+  ;; ==========================================================================
+  ;; STORAGE LAYOUT
+
+  (def '*storloc-greeting* 0x1337)
+
+  ;; ==========================================================================
+  ;; CONSTANTS
+
+  (def '*initial-greeting* 42)
+
+  (def '*greet*        0xcfae3217) ; greet()
+  (def '*greeting*     0xef690cc0) ; greeting(): public storage in Solidity
+  (def '*set-greeting* 0xb2010978) ; setGreeting(string)
+
+  ;; ==========================================================================
+  ;; STDLIB
+
+  ;; --------------------------------------------------------------------------
+  ;; @author Daniel Ellison <zigguratt>
+  ;; @notice Shifts the leftmost 4 bytes of a 32-byte number right by 28 bytes.
+  ;; @dev 0x14ab90388092664827928d90384c73d82c5bf21abb61dd7d4971fc65f4851dfb
+  ;;      0x0000000000000000000000000000000000000000000000000000000014ab9038
+  ;; @param input A 32-byte number.
+
+  (def 'shift-right (input)
+       (div input (exp 2 224)))
+
+  ;; --------------------------------------------------------------------------
+  ;; @author Ben Edgington <benjaminion>
+  ;; @notice Gets the function ID and stores it in memory for reference.
+  ;; @dev The function ID is stored at a pre-defined location 0x20 and will
+  ;;      be read from memory every time instead of duplicated on stack.
+  ;; TODO: consider lll-docs lll_abi.html#passing-data-to-a-function
+
+  (def 'mstore-function-selector
+       (mstore *memloc-function-selector*
+               (shift-right (calldataload 0x00))))
+
+  ;; --------------------------------------------------------------------------
+  ;; @author Daniel Ellison <zigguratt>
+  ;; @notice Determines whether the supplied function selector matches a known
+  ;;         one and executes <code-body> if so.
+  ;; @dev The selector is in the leftmost four bytes of the call data:
+  ;;      https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+  ;; @param function-hash The four-byte hash of a known function signature.
+  ;; @param code-body The code to run in the case of a match.
+
+  (def 'function (function-selector code-body)
+       (when (= (mload *memloc-function-selector*) function-selector)
+         code-body))
+
+  ;; --------------------------------------------------------------------------
+  ;; @author Daniel Ellison <zigguratt>
+  ;; @notice Modifier macro to prevent unintended payments.
+
+  (def 'unpayable
+       (when (callvalue) (panic)))
+
+  ;; ==========================================================================
+  ;; INIT
+
+  (seq
+    unpayable
+    (sstore *storloc-greeting* *initial-greeting*))
+
+  ;; ==========================================================================
+  ;; CODE
+
+  (returnlll
+   (seq
+     unpayable
+     mstore-function-selector
+
+     ;; change greeting value in storage
+     (def 'new-greeting (calldataload 0x04))
+     (function *set-greeting*
+               (seq
+                 (sstore *storloc-greeting* new-greeting)
+                 (stop)))
+
+     ;; return greeting value from storage
+     (function *greet*
+               (return (sload *storloc-greeting*)))
+
+     ;; for compatibility with Greeter.sol: "public storage variable"
+     (function *greeting*
+               (return (sload *storloc-greeting*)))
+
+     ;; fallback
+     (panic))))

--- a/populus/assets/Greeter.lll.abi
+++ b/populus/assets/Greeter.lll.abi
@@ -1,0 +1,50 @@
+[
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_greeting",
+                "type": "uint256"
+            }
+        ],
+        "name": "setGreeting",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "greet",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "greeting",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    }
+]

--- a/populus/assets/test_greeter_lll.py
+++ b/populus/assets/test_greeter_lll.py
@@ -1,0 +1,15 @@
+def test_greeter(chain):
+    greeter, _ = chain.provider.get_or_deploy_contract('Greeter')
+
+    greeting = greeter.call().greet()
+    assert greeting == 42
+
+
+def test_custom_greeting(chain):
+    greeter, _ = chain.provider.get_or_deploy_contract('Greeter')
+
+    set_txn_hash = greeter.transact().setGreeting(1337)
+    chain.wait.for_receipt(set_txn_hash)
+
+    greeting = greeter.call().greet()
+    assert greeting == 1337

--- a/populus/compilation/backends/__init__.py
+++ b/populus/compilation/backends/__init__.py
@@ -10,6 +10,6 @@ from .solc_auto import (  # noqa: F401
 from .viper import (  # noqa: F401
     ViperBackend,
 )
-from .lll import (  #noqa: F401
+from .lll import (  # noqa: F401
     LLLBackend,
 )

--- a/populus/compilation/backends/__init__.py
+++ b/populus/compilation/backends/__init__.py
@@ -10,3 +10,6 @@ from .solc_auto import (  # noqa: F401
 from .viper import (  # noqa: F401
     ViperBackend,
 )
+from .lll import (  #noqa: F401
+    LLLBackend,
+)

--- a/populus/compilation/backends/lll.py
+++ b/populus/compilation/backends/lll.py
@@ -1,0 +1,78 @@
+import json
+import os
+import pprint
+import subprocess
+
+from .base import (
+    BaseCompilerBackend,
+)
+from populus.utils.filesystem import (
+    is_executable_available
+)
+
+
+# FIXME: move where appropriate - separate package if needed.
+class LLLCompiler(object):
+    """ TODO """
+    def __init__(self):
+        self.lllc_binary = os.environ.get('LLLC_BINARY', 'lllc')
+        if not is_executable_available(self.lllc_binary):
+            raise FileNotFoundError("lllc compiler executable not found!")
+        return
+
+    def compile(self, code):
+        """ Passes an LLL program to the ``lllc`` compiler. """
+        proc = subprocess.Popen([self.lllc_binary, '-x'],
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
+        stdoutdata, stderrdata = proc.communicate(code)
+        return stdoutdata.rstrip()
+
+    def strip(self, bytecode):
+        """ Strips compiler-given bytecode of parts that will not be present at runtime. """
+
+        # remove deployment code: head up to (and including)
+        # ``PUSH1 0x00 CODECOPY PUSH1 0x00 RETURN STOP``
+        res = bytecode.split('6000396000f300', maxsplit=1)
+        nohead = res[-1]
+        if nohead == bytecode:
+            return ''
+        return nohead
+
+
+class LLLBackend(BaseCompilerBackend):
+    project_source_glob = ('*.lll')
+    test_source_glob = ('test_*.lll')
+
+    def get_compiled_contracts(self, source_file_paths, import_remappings):
+        compiler  = LLLCompiler()
+
+        self.logger.debug("Compiler Settings: %s", pprint.pformat(self.compiler_settings))
+
+        compiled_contracts = []
+
+        for contract_path in source_file_paths:
+            code = open(contract_path).read()
+            try:
+                with open(contract_path + '.abi') as jsonabi:
+                    abi = json.load(jsonabi)
+            except FileNotFoundError as e:
+                self.logger.error(".lll files require an accompanying .lll.abi JSON ABI file!")
+                raise e
+
+            bytecode = '0x' + compiler.compile(code)
+            bytecode_runtime = '0x' + compiler.strip(bytecode)
+
+            compiled_contracts.append({
+                'name': os.path.basename(contract_path).split('.')[0],
+                'abi': abi,
+                'bytecode': bytecode,
+                'bytecode_runtime': bytecode_runtime,
+                'linkrefs': [],
+                'linkrefs_runtime': [],
+                'source_path': contract_path
+            })
+
+        return compiled_contracts

--- a/populus/compilation/backends/lll.py
+++ b/populus/compilation/backends/lll.py
@@ -19,13 +19,14 @@ class LLLCompiler(object):
             raise FileNotFoundError("lllc compiler executable not found!")
         return
 
-    def compile(self, code):
+    def compile(self, code, cwd=None):
         """ Passes an LLL program to the ``lllc`` compiler. """
         proc = subprocess.Popen([self.lllc_binary, '-x'],
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-                                universal_newlines=True)
+                                universal_newlines=True,
+                                cwd=cwd)
         stdoutdata, stderrdata = proc.communicate(code)
         return stdoutdata.rstrip()
 
@@ -61,7 +62,7 @@ class LLLBackend(BaseCompilerBackend):
                 self.logger.error(".lll files require an accompanying .lll.abi JSON ABI file!")
                 raise e
 
-            bytecode = '0x' + compiler.compile(code)
+            bytecode = '0x' + compiler.compile(code, cwd=os.path.dirname(contract_path))
             bytecode_runtime = '0x' + compiler.strip(bytecode)
 
             compiled_contracts.append({

--- a/populus/compilation/backends/lll.py
+++ b/populus/compilation/backends/lll.py
@@ -11,9 +11,8 @@ from populus.utils.filesystem import (
 )
 
 
-# FIXME: move where appropriate - separate package if needed.
 class LLLCompiler(object):
-    """ TODO """
+    """ Interface to system-wide `lllc`. """
     def __init__(self):
         self.lllc_binary = os.environ.get('LLLC_BINARY', 'lllc')
         if not is_executable_available(self.lllc_binary):
@@ -47,7 +46,7 @@ class LLLBackend(BaseCompilerBackend):
     test_source_glob = ('test_*.lll')
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
-        compiler  = LLLCompiler()
+        compiler = LLLCompiler()
 
         self.logger.debug("Compiler Settings: %s", pprint.pformat(self.compiler_settings))
 

--- a/populus/utils/testing.py
+++ b/populus/utils/testing.py
@@ -85,3 +85,10 @@ def viper_installed():
         return True
     except ImportError:
         return False
+
+def lllc_installed():
+    lllc_binary = os.environ.get('LLLC_BINARY', 'lllc')
+    if  is_executable_available(lllc_binary):
+        return True
+    else:
+        return False

--- a/populus/utils/testing.py
+++ b/populus/utils/testing.py
@@ -10,6 +10,10 @@ from populus.utils.linking import (
     insert_link_value,
 )
 
+from populus.utils.filesystem import (
+    is_executable_available
+)
+
 
 def load_contract_fixture(fixture_path_or_name, dst_path=None):
     def outer(fn):
@@ -86,9 +90,10 @@ def viper_installed():
     except ImportError:
         return False
 
+
 def lllc_installed():
     lllc_binary = os.environ.get('LLLC_BINARY', 'lllc')
-    if  is_executable_available(lllc_binary):
+    if is_executable_available(lllc_binary):
         return True
     else:
         return False

--- a/tests/compilation/test_lll_backend.py
+++ b/tests/compilation/test_lll_backend.py
@@ -1,0 +1,14 @@
+
+import pytest
+
+from populus.compilation import (
+    compile_project_contracts,
+)
+
+from populus.utils.testing import (
+    load_contract_fixture,
+    #viper_installed,
+)
+
+# TODO: stub!
+assert False

--- a/tests/compilation/test_lll_backend.py
+++ b/tests/compilation/test_lll_backend.py
@@ -5,9 +5,17 @@ from populus.compilation import (
 )
 
 from populus.utils.testing import (
+    lllc_installed,
     load_contract_fixture,
     update_project_config,
 )
+
+
+pytestmark = pytest.mark.skipif(
+    not lllc_installed(),
+    reason="lllc not installed",
+)
+
 
 @load_contract_fixture('Greeter.lll')
 @load_contract_fixture('Greeter.lll.abi')

--- a/tests/compilation/test_lll_backend.py
+++ b/tests/compilation/test_lll_backend.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from populus.compilation import (
@@ -7,8 +6,27 @@ from populus.compilation import (
 
 from populus.utils.testing import (
     load_contract_fixture,
-    #viper_installed,
+    update_project_config,
 )
 
-# TODO: stub!
-assert False
+@load_contract_fixture('Greeter.lll')
+@load_contract_fixture('Greeter.lll.abi')
+@update_project_config(
+    (
+        'compilation.backend.class',
+        'populus.compilation.backends.LLLBackend',
+    ),
+)
+def test_compiling_lll_project_contracts(project):
+    source_paths, compiled_contracts = compile_project_contracts(project)
+
+    assert 'contracts/Greeter.lll' in source_paths
+
+    assert 'Greeter' in compiled_contracts
+    contract_data = compiled_contracts['Greeter']
+    assert 'bytecode' in contract_data
+    assert 'bytecode_runtime' in contract_data
+    assert 'abi' in contract_data
+    function_names = [x['name'] for x in contract_data['abi'] if x['type'] != 'constructor']
+    assert 'setGreeting' in function_names
+    assert 'greet' in function_names

--- a/tests/fixtures/Greeter.lll
+++ b/tests/fixtures/Greeter.lll
@@ -1,20 +1,28 @@
-;;; ---------------------------------------------------------------------------
-;;; @title Lovely Little Greeter
-;;; @author Noel Maersk <veox>
-;;; WARNING: untested!
+;;;; ==========================================================================
+;;;; @title Lovely Little Greeter
+;;;; @author Noel Maersk <veox>
 
 (seq
-  ;; --------------------------------------------------------------------------
+  ;; ==========================================================================
+  ;; MEMORY LAYOUT
+
+  (def '*memloc-function-selector* 0x20)
+
+  ;; ==========================================================================
+  ;; STORAGE LAYOUT
+
+  (def '*storloc-greeting* 0x1337)
+
+  ;; ==========================================================================
   ;; CONSTANTS
 
-  (def 'initial-greeting (lit 0x40 "Hello, lovely!.. <3"))
-  (def 'current-greeting 0x1337) ; storage location - 0xef690cc0 too confusing
+  (def '*initial-greeting* 42)
 
-  (def 'greet        0xcfae3217) ; greet()
-  (def 'greeting     0xef690cc0) ; greeting(): public storage in Solidity
-  (def 'set-greeting 0xa4136862) ; setGreeting(string)
+  (def '*greet*        0xcfae3217) ; greet()
+  (def '*greeting*     0xef690cc0) ; greeting(): public storage in Solidity
+  (def '*set-greeting* 0xb2010978) ; setGreeting(uint256)
 
-  ;; --------------------------------------------------------------------------
+  ;; ==========================================================================
   ;; STDLIB
 
   ;; --------------------------------------------------------------------------
@@ -28,38 +36,65 @@
        (div input (exp 2 224)))
 
   ;; --------------------------------------------------------------------------
+  ;; @author Ben Edgington <benjaminion>
+  ;; @notice Gets the function ID and stores it in memory for reference.
+  ;; @dev The function ID is stored at a pre-defined location 0x20 and will
+  ;;      be read from memory every time instead of duplicated on stack.
+  ;; TODO: consider lll-docs lll_abi.html#passing-data-to-a-function
+
+  (def 'mstore-function-selector
+       (mstore *memloc-function-selector*
+               (shift-right (calldataload 0x00))))
+
+  ;; --------------------------------------------------------------------------
   ;; @author Daniel Ellison <zigguratt>
-  ;; @notice Determines whether the supplied function ID matches a known
-  ;;         function hash and executes <code-body> if so.
-  ;; @dev The function ID is in the leftmost four bytes of the call data.
+  ;; @notice Determines whether the supplied function selector matches a known
+  ;;         one and executes <code-body> if so.
+  ;; @dev The selector is in the leftmost four bytes of the call data:
+  ;;      https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
   ;; @param function-hash The four-byte hash of a known function signature.
   ;; @param code-body The code to run in the case of a match.
 
-  (def 'function (function-hash code-body)
-       (when (= (shift-right (calldataload 0x00)) function-hash)
+  (def 'function (function-selector code-body)
+       (when (= (mload *memloc-function-selector*) function-selector)
          code-body))
 
   ;; --------------------------------------------------------------------------
+  ;; @author Daniel Ellison <zigguratt>
+  ;; @notice Modifier macro to prevent unintended payments.
+
+  (def 'unpayable
+       (when (callvalue) (panic)))
+
+  ;; ==========================================================================
   ;; INIT
 
-  (sstore current-greeting initial-greeting)
+  (seq
+    unpayable
+    (sstore *storloc-greeting* *initial-greeting*))
 
-  ;; --------------------------------------------------------------------------
+  ;; ==========================================================================
   ;; CODE
 
   (returnlll
    (seq
-     ;;
-     (def 'new-greeting (calldataload 0x04))
-     (function set-greeting
-               (sstore current-greeting new-greeting))
+     unpayable
+     mstore-function-selector
 
-     ;;
-     (function greet
-               (return (sload current-greeting)))
-     ;; for compatibility with Greeter.sol
-     (function greeting
-               (return (sload current-greeting)))
-     )
-   )
-  )
+     ;; change greeting value in storage
+     (def 'new-greeting (calldataload 0x04))
+     (function *set-greeting*
+               (seq
+                 (sstore *storloc-greeting* new-greeting)
+                 (stop)))
+
+     ;; return greeting value from storage
+     (function *greet*
+               (return (sload *storloc-greeting*)))
+
+     ;; for compatibility with Greeter.sol: "public storage variable"
+     (function *greeting*
+               (return (sload *storloc-greeting*)))
+
+     ;; fallback
+     (panic))))

--- a/tests/fixtures/Greeter.lll.abi
+++ b/tests/fixtures/Greeter.lll.abi
@@ -1,0 +1,50 @@
+[
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_greeting",
+                "type": "uint256"
+            }
+        ],
+        "name": "setGreeting",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "greet",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "greeting",
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    }
+]


### PR DESCRIPTION
### What's this about?

Provides limited support for LLL development. The limitations are detailed in [`docs/lll_support.rst`](https://github.com/veox/populus/blob/92ed0b7ee1fba507b82bb28843d717031d90e65b/docs/lll_support.rst).

Styled after PR #383.

Closes #400 as implemented.

### What might be wrong?

* The contract file names start with a capital letter.
* `Greeter.lll` greets with numbers instead of strings.
* `Greeter.lll{,.abi}` are duplicated between dirs `tests/fixtures` and `populus/assets`. The former is to run already-present tests. The latter is provisional, to simplify `populus init --lll` later on.
* `lllc` is provided from the [`solidity-ubuntu-trusty.zip`](https://github.com/ethereum/solidity/releases/download/v0.4.19/solidity-ubuntu-trusty.zip) file, which is actually installed to get `solc`. If the Travis builds are moved away from Ubuntu 14.04 (Trusty), the binary _might_ become unavailable.

#### Cute Animal Picture

Three languages! Wow! (gotten [here](http://www.wallpapersxl.com/wallpaper/2048x1536/funny-dogs-three-in-the-boat-354039.html), actual source unknown)

![three dogs in an inflatable boat in a pool](https://veox.pw/dump/3d.jpeg)