### PR TITLE
Document passing settings to chains.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -194,6 +194,27 @@ The above chain configuration sets up a new local private chain within your
 project.  The chain above would set it's data directory to
 ``<project-dir>/chains/my-chain/``.
 
+You can pass chain settings in ``settings`` in subkey. In the case
+of geth processes, these are directly mapped to command line arguments.
+
+Below is an example how to make the temporary chain to listen to JSON-RPC.
+
+.. code-block:: javascript
+
+    "temp": {
+      "chain": {
+        "class": "populus.chain.geth.TemporaryGethChain",
+        "settings": {
+          "rpc_port": "8548"
+        }
+        # ...
+      }
+    }
+
+For more information about possible arguments to pass geth see
+`py-geth project <https://github.com/ethereum/py-geth/blob/6584152225da1539c0d378b8284774da40024cc6/geth/wrapper.py#L104>`_
+function ``construct_popen_command()``.
+
 To simplify configuration of chains you can use the ``ChainConfig`` object.
 
 .. code-block:: python


### PR DESCRIPTION
### What was wrong?

It was not documented how to pass settings to geth in populus.json

### How was it fixed?

Added a rudimentary example.

#### Cute Animal Picture

<img width="181" alt="image" src="https://user-images.githubusercontent.com/49922/34481785-5a426e80-efb4-11e7-8288-0dce337e5f0a.png">

