### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ Always run the tests before submitting pull requests, and ideally run `tox` in
 order to check that your modifications don't break anything.
 
 Once you've made a pull request take a look at the travis build status in the
-GitHub interface and make sure the tests are runnning as you'd expect.
+GitHub interface and make sure the tests are running as you'd expect.

--- a/docs/chain.contracts.rst
+++ b/docs/chain.contracts.rst
@@ -105,7 +105,7 @@ Retrieving contract addresses
 
 You can use the  :meth:`BaseChain.registrar.get_contract_addresses` method to
 retrieve all known addresses for a given contract.  This method will return an
-interable of addresses or throw a
+iterable of addresses or throw a
 `~populus.contracts.exceptions.NoKnownAddress` exception.
 
 
@@ -180,7 +180,7 @@ dependencies are available.  This can be done with the following APIs.
 
 The :meth:`BaseChain.provider.are_contract_dependencies_available` method
 returns ``True`` if all of the necessary dependencies for the provided contract
-are avialable.  This check includes checks that the bytecode for all
+are available.  This check includes checks that the bytecode for all
 dependencies matched the expected compiled bytecode.
 
 The :meth:`BaseChain.provider.is_contract_available` method returns ``True`` if

--- a/docs/chain.introduction.rst
+++ b/docs/chain.introduction.rst
@@ -10,7 +10,7 @@ Introduction
 ------------
 
 Populus has the ability to run and/or connect to a variety of blockchains for
-you, both programatically and from the command line.
+you, both programmatically and from the command line.
 
 
 Transient Chains
@@ -83,7 +83,7 @@ The ``$ populus chain`` command handles running chains from the command line.
       run    Run the named chain.
 
 
-Running programatically from code
+Running programmatically from code
 ---------------------------------
 
 The ``populus.Project.get_chain(chain_name, chain_config=None)`` method returns

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -18,7 +18,7 @@ apply to specific project,
 and the user-scope file for the environment configs, which apply to all your projects.
 
 When a configuration key exists in both the user-config and the project-config, the project-config overrides the user-config.
-However, progrmatically you have access to both configs and can decide in runtime to choose otherwise.
+However, programmatically you have access to both configs and can decide in runtime to choose otherwise.
 
 The ``$ populus init`` command writes a minimal ``project.json`` default file to the project directory.
 
@@ -30,12 +30,12 @@ A Note for Django users
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are used to django's ``settings.py`` file, populus is quite different.
-The configuration is saved in JSON files, on purpuse.
-While saving the configuration in a Python module is convinient, and often looks nicer, there is a caveat: a python module is after all
-a programmble, running code. With an Ethereum development platform, that deals directly with money, we think
-it's safer to put the configurations in static, non programmble, and external files.
+The configuration is saved in JSON files, on purpose.
+While saving the configuration in a Python module is convenient, and often looks nicer, there is a caveat: a python module is after all
+a programmable, running code. With an Ethereum development platform, that deals directly with money, we think
+it's safer to put the configurations in static, non programmable, and external files.
 
-The option to change the configuration dynamically is still available in run time, using the ``project.config`` propery.
+The option to change the configuration dynamically is still available in run time, using the ``project.config`` property.
 But otherwise, Populus configuration comes from static JSON files. What you see is what you get, no surprises.
 
 
@@ -151,7 +151,7 @@ the following chains.
 * ``'ropsten'``: Connects to the public ethereum ropsten testnet via ``geth``.
 * ``'tester'``: Uses an ephemeral in-memory chain backed by pyethereum.
 * ``'testrpc'``: Uses an ephemeral in-memory chain backed by pyethereum.
-* ``'temp'``: Local private chain whos data directory is removed when the chain
+* ``'temp'``: Local private chain whose data directory is removed when the chain
   is shutdown.  Runs via ``geth``.
 
 .. code-block:: javascript
@@ -344,10 +344,10 @@ HTTP
     }
 
 
-The important thing to remeber is that Populus will **not** run geth for you. You will
+The important thing to remember is that Populus will **not** run geth for you. You will
 have to run geth, and then Populus will use the chain configuration to connect to this **already running** process via Web3.
 If you created a local chain with the ``$ populus chain new`` command, Populus will create an executable that you
-can use to run the chain, see :ref:`runing_local_blockchain`
+can use to run the chain, see :ref:`running_local_blockchain`
 
 
 In the next Populus version, all the chains will be configured as ``ExternalChain``

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -101,7 +101,7 @@ Example (``deploy_testnet.py``):
     from web3 import Web3
 
 
-    def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
+    def check_successful_tx(web3: Web3, txid: str, timeout=180) -> dict:
         """See if transaction went through (Solidity code did not throw).
 
         :return: Transaction receipt
@@ -144,14 +144,14 @@ Example (``deploy_testnet.py``):
             # Deploy crowdsale, open since 1970
             txhash = Crowdsale.deploy(transaction={"from": beneficiary}, args=[beneficiary, multisig_address, 1])
             print("Deploying crowdsale, tx hash is", txhash)
-            receipt = check_succesful_tx(web3, txhash)
+            receipt = check_successful_tx(web3, txhash)
             crowdsale_address = receipt["contractAddress"]
             print("Crowdsale contract address is", crowdsale_address)
 
             # Deploy token
             txhash = Token.deploy(transaction={"from": beneficiary}, args=[beneficiary])
             print("Deploying token, tx hash is", txhash)
-            receipt = check_succesful_tx(web3, txhash)
+            receipt = check_successful_tx(web3, txhash)
             token_address = receipt["contractAddress"]
             print("Token contract address is", token_address)
 
@@ -160,7 +160,7 @@ Example (``deploy_testnet.py``):
             crowdsale = Crowdsale(address=crowdsale_address)
             token = Token(address=token_address)
             txhash = crowdsale.transact({"from": beneficiary}).setToken(token_address)
-            check_succesful_tx(web3, txhash)
+            check_successful_tx(web3, txhash)
 
             # Do some contract reads to see everything looks ok
             print("Token total supply is", token.call().totalSupply())

--- a/docs/dev_cycle.intro.rst
+++ b/docs/dev_cycle.intro.rst
@@ -7,14 +7,14 @@ Background
 ----------
 
 The purpose of this tutorial is to go one step beyond the common "Hello World" Greeter example,
-to the entire developement cycle of an Ethereum smart contract, using Python. We will try to unpack
-the confusing issues, clear up the mystery, and even have some fun when you dive into blockchain and contracts developemnt.
+to the entire development cycle of an Ethereum smart contract, using Python. We will try to unpack
+the confusing issues, clear up the mystery, and even have some fun when you dive into blockchain and contracts development.
 
 The tools we will use are Populus and Web3.py
 
 .. note::
 
-    Web3 in general is the client side API that let you intreacts with the blockchain. Populus is a
+    Web3 in general is the client side API that let you interacts with the blockchain. Populus is a
     development framework, that is built on top of Web3. If you are into javascript, you can use the
     `Truffle javascript framework <http://truffleframework.com/>`_, and Web3.js which ships with the
     ``geth`` client. If you prefer Python, then Populus and Web3.py are your friends.
@@ -23,7 +23,7 @@ The tools we will use are Populus and Web3.py
 We assume that your read 1-2 intros about Ethereum and the blockchain, and know Python.
 
 You don't need the complex math of the elliptic curves, but to get a grasp of the basic concepts, and the basic idea: A system that prevents bad behaviour not by moral rules, but
-by incentives. Incentinve that make honest behaviour *more* profitable (let this bold concept sink in for a moment).
+by incentives. Incentive that make honest behaviour *more* profitable (let this bold concept sink in for a moment).
 
 Development Steps
 -----------------
@@ -52,7 +52,7 @@ the public key from the private key, but the opposite is impossible.
 
 **Address**: A combination of alphanumeric characters that is derived from the public key.
 
-**Ethereum Account**: An address that is used on the blockchain. There are inifinite potential combinations
+**Ethereum Account**: An address that is used on the blockchain. There are infinite potential combinations
 of alphanumeric characters, but only when someone has the private key that the address was derived from,
 this address can be used as an *account*.
 
@@ -71,7 +71,7 @@ that claims to sent it.
 **Mining**: Bundling a group of transactions into a block
 
 **Why mining is hard?** Because the miner needs to bundle the transactions with an additional input that requires significant
-computational effort to find. Without this addtional input, the block is not valid.
+computational effort to find. Without this additional input, the block is not valid.
 
 **Rewards**: The Ether reward that a miner gets when it finds a valid block
 
@@ -86,7 +86,7 @@ e.g. if two nodes suggest two different block for the next block, the nodes gets
 and *accepted by the majority of nodes on the blockchain*. So miners are incentivised to reject false blocks and false transactions.
 They know that if they work on a false transaction (say a cheat), then there
 is high probability that other nodes will reject it, and their work effort will be lost without rewards.
-They prefer to find valid blocks with valid transacions, and send them as fast as possible to the blockchain.
+They prefer to find valid blocks with valid transactions, and send them as fast as possible to the blockchain.
 
 **Uncles**: Miners get rewards when they find valid blocks, even if those blocks are *not* part
 of the direct line of the blockchain.
@@ -94,7 +94,7 @@ If the blockchain is ``block1`` >> ``block2`` >> ``block3`` >> ``block4``, and a
 but wasn't fast enough to introduce it to the chain, it will still get *partial* rewards.
 The faster miner, of ``block4``, will get the *full* rewards. ``block4`` is included in the direct sequence of the blockchain,
 and ``block4a``  is not used in the sequence but included as an "*uncle*".
-The idea is to spread compenstatations among miners and avoid "the winner takes it all" monopoly.
+The idea is to spread compensations among miners and avoid "the winner takes it all" monopoly.
 
 **Contract**: The word ""contract" is used for three different (albeit related) concepts:
 (1) A compiled runnable bytecode that sits on the blockchain (2) A Solidity source code contract definition
@@ -113,7 +113,7 @@ the EVM needs the ABI in order to know how to call the bytecode.
 
 **Web3**: Client side API that lets you interact with the blockchain. Web3.js is the javascript version, Web3.py is the Python one.
 
-**geth**: The official implemntation of an Ethereum blockchain node, written in Go
+**geth**: The official implementation of an Ethereum blockchain node, written in Go
 
 **gas**: The price that users pay to run computational actions on the blockchain (deploying a new contract, send money, run a contract function, storage, memory)
 
@@ -121,6 +121,6 @@ the EVM needs the ABI in order to know how to call the bytecode.
 
 **testnet**: An Ethereum blockchain for testing. It behaves exactly as mainnet, but you don't use real Ether to send money and pay for the gas
 
-**Local chain**: A blockchain that runs localy, has it's own blocks, and does not sync to any other blockchain. Useful for development
+**Local chain**: A blockchain that runs locally, has it's own blocks, and does not sync to any other blockchain. Useful for development
 and testing
 

--- a/docs/dev_cycle.part-01.rst
+++ b/docs/dev_cycle.part-01.rst
@@ -93,7 +93,7 @@ look at ``chains/horton/run_chain.sh``).
   }
 
 
-For more on the horton local chain see :ref:`runing_local_blockchain` .
+For more on the horton local chain see :ref:`running_local_blockchain` .
 
 Everything is ready.
 
@@ -109,14 +109,14 @@ Ok, time to add a new contract.
 
 .. note::
 
-    You can work with your favourite IDE. Check for Solidity extention/package. Atom.io
+    You can work with your favourite IDE. Check for Solidity extension/package. Atom.io
     has some nice Solidity packages.
 
 
 In this example we will work with a very simple contract that accepts donations for later use.
 The contract will also handle the donations value in USD.
 
-Since the ETH/USD exchange rate fluctates, typically upward, we want to track not only how much ETH the contract collected,
+Since the ETH/USD exchange rate fluctuates, typically upward, we want to track not only how much ETH the contract collected,
 but also the accumulating USD value of the donations *at the time of the donation*.
 If the ETH rate is rising, then we will probably see smaller donations
 in terms of Ether, but similar donations in terms of USD.
@@ -138,7 +138,7 @@ Quick Solidity Overview
 -----------------------
 
 **Pragma**:
-Every Solidity source should provide the compiler compatability: `pragma solidity ^0.4.11;`
+Every Solidity source should provide the compiler compatibility: `pragma solidity ^0.4.11;`
 
 **Contract definition**:
 The ``contract`` keyword starts a new contract definition, named ``Donator``.
@@ -150,12 +150,12 @@ The ``contract`` keyword starts a new contract definition, named ``Donator``.
 **State variables**:
 The contract has 4 state variables: ``donationsTotal``, ``donationsUsd``, ``donationsCount`` and ``defaultUsdRate``.
 A state variable is defined in the *contract scope*.
-State variables are saved in the contract's persisten *storage*,
+State variables are saved in the contract's persistent *storage*,
 kept after the transaction run ends, and synced to every node on the blockchain.
 
 **Visibility:**
-The ``public`` decleration ensures that all state variables and the ``donate`` function will be available for the callers
-of the contrat, in the contract's interface.
+The ``public`` declaration ensures that all state variables and the ``donate`` function will be available for the callers
+of the contract, in the contract's interface.
 
 .. note::
     For the public state variables, the compiler actually creates an accessor function
@@ -163,7 +163,7 @@ of the contrat, in the contract's interface.
 
 **Data types**:
 Since we are dealing with numbers, the only data type we use here is ``uint``, unsigned integer. The ``int`` and ``uint``
-are declated in steps of 8 bits, ``unint8``, ``uint16`` etc. When the bits indicator is omitted, like ``int`` or ``uint``, the compiler will
+are declared in steps of 8 bits, ``unint8``, ``uint16`` etc. When the bits indicator is omitted, like ``int`` or ``uint``, the compiler will
 assumes ``uint256``.
 
 .. note::
@@ -171,8 +171,8 @@ assumes ``uint256``.
     If you know in advance the the maximum size of a variable, better to limit the type and save the gas of extra
     memory or storage.
 
-As of version 0.4.17 Solidity does *not* support decimal point types. If you need decimal point, you will have to manauly handle
-the fixed point calculations with integers. For the sake of simplicty, the example uses only ints.
+As of version 0.4.17 Solidity does *not* support decimal point types. If you need decimal point, you will have to manually handle
+the fixed point calculations with integers. For the sake of simplicity, the example uses only ints.
 
 
 **Constructor**:
@@ -187,7 +187,7 @@ updates the total donated, both of Ether and USD value. It also updates the defa
 
 **Magic Variables**:
 In every contract you get three magic variables in the global scope: ``msg``, ``block`` and ``tx``. You can use these
-variable without prior decleration or assignment. To find out how much
+variable without prior declaration or assignment. To find out how much
 Ether was sent, use ``msg.value``.
 
 **Modifiers**:
@@ -233,8 +233,8 @@ This Donator example is fairly simple.
 
 If you are following the Ethereum world for a while, you probably noticed that many Ethereum projects are much more complex.
 People and companies try to use contracts to manage distributed activity among very large groups,
-assuming you need special, usually complex, code and strategies that defend against bad actores.
-Some noticeable initiatives are the decentrelized autonomous organizations (DAO),
+assuming you need special, usually complex, code and strategies that defend against bad actors.
+Some noticeable initiatives are the decentralized autonomous organizations (DAO),
 getting groups decisions where the voting rights are proportional to the Ether the voter sent to the contract,
 or crowd funding with Ether, initial coin offerings (ICO),
 feeds that send the contract up-to-date data from the "outside world", etc.

--- a/docs/dev_cycle.part-02.rst
+++ b/docs/dev_cycle.part-02.rst
@@ -68,7 +68,7 @@ If you copy-pasted the ``Donator`` contract example, you will get:
 What's that? actually it's not that bad. You can ignore the Python traceback, which is just the Populus call stack until the actual
 call to the compiler.
 
-To undersatnd what went wrong, just look at the compiler's output. The error message is quite clear:
+To understand what went wrong, just look at the compiler's output. The error message is quite clear:
 
 .. code-block:: bash
 
@@ -92,7 +92,7 @@ The fixed line should be:
 .. note::
 
   Try the `online IDE <https://remix.ethereum.org>`_ , which has great interactive compiler and web-form like interface
-  to call the contract and it's funcitons.
+  to call the contract and it's functions.
 
 
 Try to compile again:
@@ -123,7 +123,7 @@ Tester Deployment
 You now have two compiled contracts, ready for deployment.
 
 The first deployment step is to verify that it works on the ``tester`` chain. This is an ephemeral blockchain.
-It runs localy, and resets each time is starts. The state of the chain when it runs is kept only in memory,
+It runs locally, and resets each time is starts. The state of the chain when it runs is kept only in memory,
 and cleared when done. It's a great tool for a testing.
 
 Deploy to the ``tester`` chain:
@@ -158,7 +158,7 @@ Deploy to the ``tester`` chain:
 When you deploy a contract Populus re-compiles *all* the contracts, but deploys only those you asked for.
 
 Well, deployment works. Since the ``tester`` chain is *not* persistent, everything was deleted, but the deployment should work on persistent
-chains: it's the same Ethereum protocol. Check for yourself and run the deploy again, it will re-dploy exactly the same,since
+chains: it's the same Ethereum protocol. Check for yourself and run the deploy again, it will re-deploy exactly the same,since
 each starts from a reset state.
 
 

--- a/docs/dev_cycle.part-03.rst
+++ b/docs/dev_cycle.part-03.rst
@@ -58,9 +58,9 @@ to ``testnet``, then we have another "contract", the code that sits on ``testnet
 which is another blockchain, we now have three contracts: the source file, the bytecode on ``testnet``, and the bytecode on ``mainnet``.
 
 But wait, there is more! To interact with an *existing* contract on say ``mainnet``, we need a Web3 "contract" *object*. This object does
-not need the solidity source, since the bytcode is alreadt compiled and deployed. It does need the ABI: the ABI is the detailed
+not need the solidity source, since the bytecode is already compiled and deployed. It does need the ABI: the ABI is the detailed
 specification of the functions and arguments structure of the *bytecode* contract's interface, and the address of this *bytecode* contract
-on the mainnet. Again, a contract might be the bytecode on the blockchain, a Solidty source, or a web3.py contract object.
+on the mainnet. Again, a contract might be the bytecode on the blockchain, a Solidity source, or a web3.py contract object.
 
 
 Testing a Contract
@@ -81,7 +81,7 @@ Add the first test:
 
 .. code-block:: shell
 
-  $ nano tests/test_donatory.py
+  $ nano tests/test_donator.py
 
 The test file should look as follows:
 
@@ -178,7 +178,7 @@ Run the test:
 
 .. note::
 
-  Usually you don't want to use ```--disable-pytest-warnings```, because the warnings provide important infromation.
+  Usually you don't want to use ```--disable-pytest-warnings```, because the warnings provide important information.
   We use it here to make the output less confusing, for the tutorial only.
 
 

--- a/docs/dev_cycle.part-04.rst
+++ b/docs/dev_cycle.part-04.rst
@@ -39,7 +39,7 @@ After the edit, the file should look as follows:
 You added another test, ``test_donations``. The second test is similar to the first one:
 
 **[1] Get the chain**: The test function accepts the ``chain`` argument, the auto-generated Python object that
-corresponds to a ``tester`` chain. Reminder: the ``tester`` chain is ephimeral, in memory, and reset
+corresponds to a ``tester`` chain. Reminder: the ``tester`` chain is ephemeral, in memory, and reset
 on each test function.
 
 **[2] Get the contract**: With the magic function ``get_or_deploy_contract`` Populus compiles the `Donator` contract,
@@ -55,7 +55,7 @@ object with Python methods. This object is stored in the ``donator`` variable.
 Reminder: we have two options to interact with a contract on the blockchain, *transactions* and *calls*.
 With Populus, you initiate a transaction with ``transact``, and a call with ``call``:
 
-* *Transactions*: Send a transaction, run the contract code, transfer funds, and *change* the state of the contract and it's balance. This change will be permenant, and synced to the entire blockchain.
+* *Transactions*: Send a transaction, run the contract code, transfer funds, and *change* the state of the contract and it's balance. This change will be permanent, and synced to the entire blockchain.
 
 * *Call*: Behaves exactly as a transaction, but once done, everything is revert and no state is changed. A call is kinda "dry-run", and an efficient way to query the current state without expensive gas costs.
 
@@ -88,7 +88,7 @@ Populus gives you a *Python* interface to a bytecode contract. Nice, no?
 **[6] Asserts**: We expect the ``donationsTotal`` to be ``500 + 650 = 1150``, the ``donationsCount`` is 2,
 and the ``defaultUsdRate`` to match the last update, 380.
 
-The test gets the varaibles with ``call``, and should update instanrly because it's a local ``tester`` chain. On a distributed
+The test gets the variables with ``call``, and should update instantly because it's a local ``tester`` chain. On a distributed
 blockchain it will take sometime until the transactions are mined and actually change the state.
 
 Run the test:
@@ -160,10 +160,10 @@ and a total *USD* value of $4
 
     donator.transact({'value':(2 * ONE_ETH_IN_WEI)}).donate(5)
 
-Donate Wei worth of *2* Ether, where the effective ETH/USD rate is $5 (no markets sepculations on the tutorial)
+Donate Wei worth of *2* Ether, where the effective ETH/USD rate is $5 (no markets speculations on the tutorial)
 It's $5 per Ether, and total *USD* value of 2 * $5 = $10
 
-Hence we excpect the total *USD* value of these two donations to be $4 + $10 = $14
+Hence we expect the total *USD* value of these two donations to be $4 + $10 = $14
 
 .. code-block:: python
 

--- a/docs/dev_cycle.part-05.rst
+++ b/docs/dev_cycle.part-05.rst
@@ -93,7 +93,7 @@ Interim Summary
     * Working Contract
     * All tests pass
 
-The next step is to deploy the contract to a persisetent chain.
+The next step is to deploy the contract to a persistent chain.
 
 
 

--- a/docs/dev_cycle.part-06.rst
+++ b/docs/dev_cycle.part-06.rst
@@ -6,12 +6,12 @@ Part 6: Contract Instance on a Local Chain
 Deploy to a Local Chain
 -----------------------
 
-So far we worked with the ``tester`` chain, which is ephimeral: it runs only on memory, reset in each test,
+So far we worked with the ``tester`` chain, which is ephemeral: it runs only on memory, reset in each test,
 and nothing is saved after it's done.
 
-The easiest *persisten* chain to start with, is a private local chain. It runs on your machine, saved to hard drive,
+The easiest *persistent* chain to start with, is a private local chain. It runs on your machine, saved to hard drive,
 for persistency, and fast to respond. Yet it keeps the same Ethereum protocol, so everything that works locally
-should work on ``testnet`` and ``mainnet``. See :ref:`runing_local_blockchain`
+should work on ``testnet`` and ``mainnet``. See :ref:`running_local_blockchain`
 
 You already have ``horton``, a local chain, which you set when you started the project.
 
@@ -81,7 +81,7 @@ run script, ``run_chain.sh``.
 The same account also gets an allocation of (dummy) Ether
 in the first block of the ``horton`` local chain, and this is why we can use ``--no-wait-for-sync``.
 Otherwise, if your account get money from a transaction in a far (far away) block, that
-was not synced yet localy, geth thinks that you don't have the funds for gas, and refuses to
+was not synced yet locally, geth thinks that you don't have the funds for gas, and refuses to
 deploy until you sync.
 
 .. note::
@@ -120,8 +120,8 @@ The script should look as follows:
     else:
         print("Deploy Transaction {tx}".format(tx=deploy_tx_hash))
 
-It starts by initiating a Populus ``Project``. The Project is the enrty point
-to the Populus API, where you can get all the relevant resources programatically.
+It starts by initiating a Populus ``Project``. The Project is the entry point
+to the Populus API, where you can get all the relevant resources programmatically.
 
 .. note::
 
@@ -137,7 +137,7 @@ The next line gets the ``horton`` chain object:
 Using ``get_chain``, the Populus Project object has access to any chain that is defined in the project's configuration file,
 ``project.json``, and the user-scope configuration file, ``~/.popuplus/config.json``. Go ahead
 and take a look at the ``chains`` key in those files. Populus' config files are in JSON: not so pretty to the Pythonic
-developer habbits, but for blockchain development it safer to use non programmble, static, external files (and hey, you got
+developer habits, but for blockchain development it safer to use non programmable, static, external files (and hey, you got
 to admit that Populus saves you form quite a lot javascript).
 
 
@@ -283,7 +283,7 @@ missed it too.
 
 .. code-block:: shell
 
-    $ nano contracts/Greete.sol
+    $ nano contracts/Greeter.sol
 
 Edit the contract file:
 
@@ -298,7 +298,7 @@ Deploy to ``horton``, after you make sure the chain runs:
     $ populus deploy --chain horton Greeter --no-wait-for-sync
 
 
-You should see the usuall deployment log, and in a few seconds the contract creation transaction is picked and mined:
+You should see the usual deployment log, and in a few seconds the contract creation transaction is picked and mined:
 
 .. code-block:: shell
 
@@ -528,5 +528,5 @@ Interim Summary
 
 * You deployed a persistent contract instance to a local chain
 * You interacted with the ``Project`` object, which is the entry point to the Populus API
-* You deployed the same Solidity source file on two seprated local chains, ``horton`` and ``morty``
+* You deployed the same Solidity source file on two separated local chains, ``horton`` and ``morty``
 * Deployments are saved in the the ``registrar``

--- a/docs/dev_cycle.part-07.rst
+++ b/docs/dev_cycle.part-07.rst
@@ -46,7 +46,7 @@ Calls are useful to query an *existing* contract state, without any changes,
 when a local synced node can just hand you this info. It's also useful as a "dry-run" for transactions: you run a ''call'', make sure
 everything is working, then send the real transaction.
 
-To access a conract function with ``call``, in the same way you have done with the tests,
+To access a contract function with ``call``, in the same way you have done with the tests,
 use ``contract_obj.call().foo(arg1,arg2...)``
 where ``foo`` is the contract function. Then ``call()`` returns an object that exposed the contract instance functions
 in Python.
@@ -85,7 +85,7 @@ And add a few lines, as follows:
     avg_donation = donationsTotal/donationsCount if donationsCount > 0 else 0
     status_msg = (
         "Total of {:,.2f} Ether accepted in {:,} donations, "
-        "an avergage of {:,.2f} Wei per donation."
+        "an average of {:,.2f} Wei per donation."
         )
 
     print (status_msg.format(total_ether, donationsCount, avg_donation))
@@ -98,7 +98,7 @@ and once you have the ``chain`` you can get the contract *instance* on that chai
 Then we get the ``donationsCount`` and the ``donationsTotal`` with ``call``. Populus, via Web3, calls
 the running geth node, and geth grabs and return these two state variables
 from the contract's storage. Even if we had used geth as a node to ``mainnet``, a sync node can get this info
-localy.
+locally.
 
 These are the same public variables that you declared in the ``Donator`` Solidity source:
 
@@ -125,7 +125,7 @@ Run the script:
 
     Donator address on horton is 0xb8d9d2afbe18fd6ac43042164ece9691eb9288ed
     The contract is already deployed on the chain
-    Total of 0.00 Ether accepted in 0 donations, an avergage of 0.00 Wei per donation.
+    Total of 0.00 Ether accepted in 0 donations, an average of 0.00 Wei per donation.
 
 
 Note that we don't need an expensive state variable
@@ -183,7 +183,7 @@ Update the script:
     avg_donation = donationsTotal/donationsCount if donationsCount > 0 else 0
     status_msg = (
         "Total of {:,.2f} Ether accepted in {:,} donations, "
-        "an avergage of {:,.2f} Wei per donation."
+        "an average of {:,.2f} Wei per donation."
         )
 
     print (status_msg.format(total_ether, donationsCount, avg_donation))
@@ -214,7 +214,7 @@ The ``value`` is obviously the amount you send *in Wei*, and the ``from`` is the
 **Coinbase Account**
 
 Until now you didn't provide any account, because in the tests the ``tester`` chain magically creates and unlocks
-ad-hoc accounts. With a *persistent* chain you have to explictly provide the account.
+ad-hoc accounts. With a *persistent* chain you have to explicitly provide the account.
 
 Luckily, when Populus created the local ``horton`` chain it also created a default wallet file, a password file that unlocks the wallet,
 and included the ``--unlock`` and ``--password`` arguments for geth in the run script, ``run_chain.sh``. When you run
@@ -233,7 +233,7 @@ one account, the one that Populus created, and it's automatically assigned as th
 .. note::
 
     The wallet files are saved in the chain's ``keystore`` directory. For more see the tutorial on :ref:`tutorial_wallets` and
-    :ref:`tutorial_accounts`. For a more in-depth discussion see `geth accounts managment <https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts>`_
+    :ref:`tutorial_accounts`. For a more in-depth discussion see `geth accounts management <https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts>`_
 
 
 Finally, the script sends the transaction with ``transact``:
@@ -252,7 +252,7 @@ Ok. Run the script, after you make sure that ``horton`` is running:
 
     Donator address on horton is 0xb8d9d2afbe18fd6ac43042164ece9691eb9288ed
     The contract is already deployed on the chain
-    Total of 0.00 Ether accepted in 0 donations, an avergage of 0.00 Ether per donation.
+    Total of 0.00 Ether accepted in 0 donations, an average of 0.00 Ether per donation.
     Thank you for the donation! Tx hash 0xbe9d182a508ec3a7efc3ada8cfb134647b39feec4a7eb018ef91cc38e216ddbc
 
 Worked. The transaction was sent, yet we still don't see it. Run again:
@@ -263,7 +263,7 @@ Worked. The transaction was sent, yet we still don't see it. Run again:
 
     Donator address on horton is 0xb8d9d2afbe18fd6ac43042164ece9691eb9288ed
     The contract is already deployed on the chain
-    Total of 3.00 Ether accepted in 1 donations, an avergage of 3,000,000,000,000,000,000.00 Wei per donation.
+    Total of 3.00 Ether accepted in 1 donations, an average of 3,000,000,000,000,000,000.00 Wei per donation.
     Thank you for the donation! Tx hash 0xf6d40adfedf1882e7543c4ef96803bd790127afdc67e40a4c7d91d29884ad182
 
 First donation accepted! Run again:
@@ -274,7 +274,7 @@ First donation accepted! Run again:
 
     Donator address on horton is 0xb8d9d2afbe18fd6ac43042164ece9691eb9288ed
     The contract is already deployed on the chain
-    Total of 4.00 Ether accepted in 2 donations, an avergage of 2,000,000,000,000,000,000.00 Wei per donation.
+    Total of 4.00 Ether accepted in 2 donations, an average of 2,000,000,000,000,000,000.00 Wei per donation.
     Thank you for the donation! Tx hash 0x21bd87b9db76b54a48c5a12a4bf7930a0e45480f5af5d0745cb2e8b4a438c5af
 
 And they just keep coming.
@@ -292,7 +292,7 @@ and mine it:
     INFO [10-20|01:49:05] Commit new mining work                   number=3920 txs=1 uncles=0 elapsed=735.282µs
     INFO [10-20|01:49:21] Successfully sealed new block
 
-Check the persistancy of the instance again. Stop the ``horton`` chain, press Ctrl+C in it's terminal window,
+Check the persistency of the instance again. Stop the ``horton`` chain, press Ctrl+C in it's terminal window,
 and then re-run it with ``chains/horton/./run_chain.sh``.
 
 Run the script again:
@@ -303,7 +303,7 @@ Run the script again:
 
     Donator address on horton is 0xb8d9d2afbe18fd6ac43042164ece9691eb9288ed
     The contract is already deployed on the chain
-    Total of 7.00 Ether accepted in 3 donations, an avergage of 2,333,333,333,333,333,504.00 Wei per donation.
+    Total of 7.00 Ether accepted in 3 donations, an average of 2,333,333,333,333,333,504.00 Wei per donation.
     Thank you for the donation! Tx hash 0x8a595949271f17a2a57a8b2f37f409fb1ee809c209bcbcf513706afdee922323
 
 Oh, it's so easy to donate when a genesis block allocates you billion something.
@@ -321,11 +321,11 @@ On ``mainent`` and ``testnet``, to the entire blockchain nodes network.
     from Populus, and let the ``fallback`` do one thing - call this function.
 
 
-Programatically Access to a Contract Instance
+Programmatically Access to a Contract Instance
 ---------------------------------------------
 
 The script is very simple, but it gives a glimpse how to use Populus as bridge between your Python application
-and the Ethereum Blockchain. As an excercise, update the script so it prompts for donation amount, or work with
+and the Ethereum Blockchain. As an exercise, update the script so it prompts for donation amount, or work with
 the ``Donator`` instance on the *morty* local chain.
 
 This is another point that you'll appreciate Populus: not only it helps

--- a/docs/dev_cycle.part-08.rst
+++ b/docs/dev_cycle.part-08.rst
@@ -68,8 +68,8 @@ It allows other *local* processes to access the running node. Web3, as another p
 Console Interaction with a Contract Instance
 --------------------------------------------
 
-We can interact with a contract instance via the Python shell as well. We will do things in a bit convuluted manual way here,
-for the sake of demostration. During the regular development process, Populus does all that
+We can interact with a contract instance via the Python shell as well. We will do things in a bit convoluted manual way here,
+for the sake of demonstration. During the regular development process, Populus does all that
 for you.
 
 To get a handle to the ``Donator`` instance on ``horton`` we need (a) it's **address**, where the bytecode sits,
@@ -159,7 +159,7 @@ Solc produced the ABI in JSON. Convert it to Python:
     >>> import json
     >>> abi = json.loads(abi_js)
 
-Ready to instanciate a contract *object*:
+Ready to instantiate a contract *object*:
 
 .. code-block:: python
 
@@ -196,7 +196,7 @@ object and returns it to you (and if the contract is not deployed, it will deplo
 
     Worth to remind again. **Never** call a contract with just an address and an ABI. You never know
     what the code at that address does behind the ABI. The only safe way is either if you
-    absolutly know and trust the author, or to check it yourself.
+    absolutely know and trust the author, or to check it yourself.
     Get the source code from the author, make sure the source is safe, then compile it yourself,
     and verify that the compiled bytecode
     on your side is **exactly the same** as the bytecode at the said address on the blockchain.
@@ -206,11 +206,11 @@ Note that ``donationsTotal`` is *not* the account balance as it is saved in the 
 It's rather a *contract* state. If we made a calculation mistake with ``donationsTotal`` then it won't
 reflect the actual Ether balance of the contract.
 
-So all these doantions are not in the balance? Let's see:
+So all these donations are not in the balance? Let's see:
 
 .. code-block:: python
 
-    >>> w3.eth.getBalacne(donator.address)
+    >>> w3.eth.getBalance(donator.address)
     8000000000000000000
 
 Phew. It's OK. The ``donationsTotal`` is exactly the same as the "official" balance.
@@ -248,7 +248,7 @@ Send the transaction, assume the effective ETH/USD exchange rate is $7 per Ether
 
 The hash is the *transaction's* hash. On local chains
 transactions are picked and mined in seconds, so we can expect to see the changed state almost
-immidiately:
+immediately:
 
 .. code-block:: python
 
@@ -260,7 +260,7 @@ immidiately:
     Decimal('13')
 
 You can also send a transaction *directly* to the chain, instead of via the ``donator`` contract object.
-It's a good opportunity, too, for a little more generousity. Maybe you go through the roof and donate
+It's a good opportunity, too, for a little more generosity. Maybe you go through the roof and donate
 100 Ether!
 
 .. code-block:: python
@@ -288,7 +288,7 @@ at all. How did the donations total and balance increased? Take a look at the tr
 
     >>> transaction = {'value':100*(10**18),'from':w3.eth.coinbase,'to':donator.address}
 
-No mention of the ``donate`` function, yet the 100 Ether were transfered and donated. How?
+No mention of the ``donate`` function, yet the 100 Ether were transferred and donated. How?
 
 If you answered *fallback* you would be correct. The contract has a fallback function:
 
@@ -392,22 +392,22 @@ Unlock this new account:
 Getting Info from the Blockchain
 --------------------------------
 
-The Web3 API has many usefull calls to query and get info from the blockchain. All this information is publicly
+The Web3 API has many useful calls to query and get info from the blockchain. All this information is publicly
 available, and there are many websites that present it with a GUI, like `etherscan.io <https://etherscan.io/>`_.
-The same info is available programmaticaly with Web3.
+The same info is available programmatically with Web3.
 
 Quit the ``horton`` chain and start a new Python shell.
 
 Mainnet with Infura.io
 ''''''''''''''''''''''
 
-As an endpoint we will use ``infura.io``. It's a publicly avaialble blockchain node, by Consensys, which is great
+As an endpoint we will use ``infura.io``. It's a publicly available blockchain node, by Consensys, which is great
 for read-only queries.
 
 Infura is a remote node, so you will use the ``HTTPProvider``.
 
 .. note::
-    Reminder: IPC, by design, allows only *local* processes to hook to the endpoint. Proccesses that
+    Reminder: IPC, by design, allows only *local* processes to hook to the endpoint. Processes that
     run on the same machine. IPC is safer if you have to unlock an account,
     but for *read-only* queries remote HTTP is perfectly OK. Did we asked you already
     to look at :ref:`a_word_of_caution`? We thought so.
@@ -462,7 +462,7 @@ This transaction details:
 .. note::
 
     If you will use block number 4402735, you should get **exactly** the same output as shown above.
-    This is the ``mainent``, which is synced accross all the nodes, and every node will return the same info.
+    This is the ``mainent``, which is synced across all the nodes, and every node will return the same info.
     The local chains ``horton`` or ``morty`` run a private instance, so every machine produces it's own blocks and hashes.
     Not so on the global, real blockchain, where all the nodes are synced
     (which is the crux of the whole blockchain idea).
@@ -508,7 +508,7 @@ You will see another ipc path, and hooking to it will open a Web3 instance to th
 .. note::
 
     When you run geth for the first time, syncing can take time. The best way is to just to let geth run without
-    interuption until it synced.
+    interruption until it synced.
 
 .. note::
 

--- a/docs/dev_cycle.part-09.rst
+++ b/docs/dev_cycle.part-09.rst
@@ -10,8 +10,8 @@ Well, time to get out some of the donations, for a good cause!
 Available Balance
 -----------------
 
-First, we will check the balanc. The balance of an Ethereum account
-is saved as a blockchain status for an *address*, wether that address has a contract or not.
+First, we will check the balance. The balance of an Ethereum account
+is saved as a blockchain status for an *address*, whether that address has a contract or not.
 
 In addition to the "official" balance,
 the contract manages a ``total_donations`` state variable that should be the same.
@@ -99,7 +99,7 @@ It's OK. Neither do we.
 
 
 The contract has **no** method to *withdraw* the Ether. If you, as the contract author, don't implement a way to withdraw funds
-or send them to another account, there is **no built in way to release the money**.  The Ether is stucked on the contract
+or send them to another account, there is **no built in way to release the money**.  The Ether is stuck on the contract
 balance forever. As far as the blockchain is concerned, those 113 Ether will remain in the balance of the ``Donator``
 address, and you will not be able to use them.
 
@@ -116,9 +116,9 @@ the ``Donator`` will just continue to hold these 113 Ether. In other words, they
 .. note::
 
     The blockchain "state" is not a physical property of nature. The state is a consensus
-    among the majority of the nodes on the blockchain. If, theoreticaly, all the nodes decide to wipe out an account
+    among the majority of the nodes on the blockchain. If, theoretically, all the nodes decide to wipe out an account
     balance, they can do it. A single node can't, but the entire network can. It's  unlikely to happen, but it's
-    a theoretical possiblility you should be aware of. It happend once, after the DAO hack, where all the nodes
+    a theoretical possibility you should be aware of. It happened once, after the DAO hack, where all the nodes
     agreed on a *hard fork*, a forced update of the blockchain state, which reverted the hack.
     See `a good discussion of the issue on Quartz <https://qz.com/730004/everything-you-need-to-know-about-the-ethereum-hard-fork/>`_.
 
@@ -129,7 +129,7 @@ Withdraw Funds from a Contract, Take 2
 --------------------------------------
 
 Don't sweat those lost Ether. After all, what are 113 dummy Ethers out of a billion something Ether
-in your local ``horton`` chain. With the ``horton`` chain, you can absolutly afford it. And if it will
+in your local ``horton`` chain. With the ``horton`` chain, you can absolutely afford it. And if it will
 prevent you from loosing real Ether on ``mainent`` in the future, then the cost/utility ratio of this lesson is excellent. Wish we could
 pay for more lessons with dummy Ether, if we were asked (but nobody is asking).
 
@@ -165,7 +165,7 @@ The send is enclosed in a ``require`` clause, so if something failed everything 
 .. warning::
 
     This is a very naive way to handle money, only for the sake of demonstration.
-    In the next chapter we will limit the withdrwal only to the contract owner.
+    In the next chapter we will limit the withdrawal only to the contract owner.
     Usually contracts keep track of beneficiaries and the money they are allowed
     to withdraw.
 
@@ -369,7 +369,7 @@ Open a Python shell and create a new account:
 
 To withdraw money, the withdrawing account must send a transaction.
 If successful, this transaction will change the state of the blockchain: the contract's account sends Ether,
-another account recieves it.
+another account receives it.
 
 The ``'from'`` key of the transaction will be this *new_account*, the withdrawer. Type:
 

--- a/docs/dev_cycle.part-10.rst
+++ b/docs/dev_cycle.part-10.rst
@@ -27,14 +27,14 @@ If you recall the withdraw function from the contract:
       require(msg.sender.send(this.balance));
         }
 
-The ``withdrawAll`` function just sends the entire balane, ``this.balance``,
+The ``withdrawAll`` function just sends the entire balance, ``this.balance``,
 to whoever request it. Send everything to ``msg.sender``, without any further verification.
 
-A better implemntation would be to allow **only the owner of the contract to withdraw the funds**. An *owne*, in the Ethereum
+A better implementation would be to allow **only the owner of the contract to withdraw the funds**. An *owner*, in the Ethereum
 world, is an *account*. An *address*. The owner is the account that the contract creation transaction was sent from.
 
-Restricting persmission to run some actions only to the owner is a very common design pattern.  There are many
-open-source implemntations of this pattern, and we will work here with the `OpenZeppelin <https://openzeppelin.org/>`_ library.
+Restricting permission to run some actions only to the owner is a very common design pattern.  There are many
+open-source implementations of this pattern, and we will work here with the `OpenZeppelin <https://openzeppelin.org/>`_ library.
 
 .. note::
 
@@ -52,7 +52,7 @@ This is the OpenZeppelin `Ownable.sol <https://github.com/OpenZeppelin/zeppelin-
    :language: solidity
 
 
-Save it to your conatracts directory:
+Save it to your contracts directory:
 
 
 .. code-block:: shell
@@ -60,7 +60,7 @@ Save it to your conatracts directory:
   $ nano contracts Ownable.sol
 
 
-Inheritence & Imports
+Inheritance & Imports
 ---------------------
 
 Create the new improved ``Donator3``:
@@ -91,7 +91,7 @@ is used for an import of a file in the same directory.
         require(msg.sender.send(this.balance));
           }
 
-The ``onlyOwner`` modifier was *not* defined in ``Donator3``, but it is inhereted,
+The ``onlyOwner`` modifier was *not* defined in ``Donator3``, but it is inherited,
 and thus can be used in the subclass.
 
 Your contracts directory should look as follows:
@@ -119,13 +119,13 @@ Compile the project:
   - contracts/Greeter.sol:Greeter
   - contracts/Ownable.sol:Ownable
 
-Compilation works, ``solc`` successfuly found ``Ownable.sol`` and imported it.
+Compilation works, ``solc`` successfully found ``Ownable.sol`` and imported it.
 
 Testing the Subclass Contract
 -----------------------------
 
-The test is similar to a regular contract test. All the parents' memebers are inherited and available for testing
-(if a parent member was overidden, use ``super`` to access the parent member)
+The test is similar to a regular contract test. All the parents' members are inherited and available for testing
+(if a parent member was overridden, use ``super`` to access the parent member)
 
 Add a test:
 
@@ -171,7 +171,7 @@ The test should look as follows:
 
 The test is similar to the previous tests. Py.test and the Populus plugin provide
 a ``chain`` fixture, as an argument to the test function which is a handle to the ``tester`` ephemeral chain.
-``Donator3`` is deployed, and the test function gets a contract object to ``doantor3``.
+``Donator3`` is deployed, and the test function gets a contract object to ``donator3``.
 
 Then the test creates a second account, ``non_owner``, unlocks it, and send to this account 1 Ether to pay for the gas.
 Next, send 42 Ether to the contract.
@@ -291,7 +291,7 @@ The test should fail:
 Yes. ``donator3.call().owner`` is wrong. Confusing. Reminder: ``owner`` should be accessed as a *function*,
 and *not* as a property, The compiler builds these functions for every public state variable.
 
-Fix every occurence of ``call().owner`` to ``call().owner()``. E.g., into:
+Fix every occurrence of ``call().owner`` to ``call().owner()``. E.g., into:
 
 .. code-block:: python
 
@@ -381,12 +381,12 @@ Run the test:
 
 Ok, all the inherited members passed: The ``Ownable`` constructor that sets ``owner`` ran when you deployed
 it's subclass, ``Donator3``. The parent modifier ``onlyOwner`` works as a modifier to a subclass function,
-and the ``transferOwnership`` parent's funcion can be called by clients via the subclass interface.
+and the ``transferOwnership`` parent's function can be called by clients via the subclass interface.
 
 .. note::
 
   If you will deploy ``Donator3`` to a local chain, say ``horton``, and look at the ``registrar.json``, you
-  will not see an entry for ``Ownable``. The reason is that although Solidity has a full complex multiple inheritence
+  will not see an entry for ``Ownable``. The reason is that although Solidity has a full complex multiple inheritance
   model (and ``super``), the final result is once contract. Solidity just copies the inherited code to this contract.
 
 
@@ -396,4 +396,4 @@ Interim Summary
 * You used an open sourced contract
 * You imported one contract to another
 * You added an ownership control to a contract
-* You used inheritence and tested it
+* You used inheritance and tested it

--- a/docs/dev_cycle.part-11.rst
+++ b/docs/dev_cycle.part-11.rst
@@ -11,7 +11,7 @@ it's status is "pending", and you will have to wait until a miner picks it, incl
 a block, and the block is accepted by the blockchain. This can take a few minutes.
 
 To track when a transaction is accepted, you use an ``event``. An event is a way to to write an indexable
-log entry to the transaction reciept. Once the transaction is accepted, the receipt and the logs are included in the
+log entry to the transaction receipt. Once the transaction is accepted, the receipt and the logs are included in the
 block as well, and you can watch every new block until the log entry you are looking for appears.
 
 

--- a/docs/dev_cycle.part-12.rst
+++ b/docs/dev_cycle.part-12.rst
@@ -41,7 +41,7 @@ True, Solidity source files and compiled data are *not* chain related, only the 
 chain are. But when you call a contract from a ``chain``, Populus will either find the instance on that chain, or
 compiles and deploys a new instance. Similar code is used regardless of the contract's state. E.g., the same code
 is used when Populus needs to re-deploy on each test run with the ``tester`` chain, and
-when you interact with a presistent contract isnstance on a local chain or ``mainnet``.
+when you interact with a persistent contract instance on a local chain or ``mainnet``.
 
 So with the ``chain`` object, you have one consistent interface, no matter what the underlying
 contract state is. See :ref:`what is a contract <what_is_a_contract>`
@@ -84,7 +84,7 @@ A subclass of ``web3.contract.Contract``.
 It is a Python object, with Python methods, that lets you interact with a corresponding
 contract instance on a blockchain.
 
-Usually you will not instanciate it directly, but will get it from a contract factory. Populus
+Usually you will not instantiate it directly, but will get it from a contract factory. Populus
 keeps track of deployments, addresses, compiled data, abi, etc, and uses this info to create the
 ``PopulusContract`` for you.
 
@@ -115,7 +115,7 @@ In both files, the chain settings appears under the ``chains`` key.
 .. note::
 
     If the same chain name appears in both the project config and the user config,
-    the project config name will overide the user-scope config
+    the project config name will override the user-scope config
 
 
 Chain Classes
@@ -186,8 +186,8 @@ Perhaps the most powerful line in the Populus API
 **[1]** If the contract's is *already* deployed, same as ``get_contract``
 
 **[2]** If the contract is *not* deployed, Populus will compile it, prepare a deployment transaction,
-calculte the gas estimate, send and wait for the deployment to a new address,
-verify the byte code, saves the deployment details to the reigstrar, and *then* create the Python
+calculate the gas estimate, send and wait for the deployment to a new address,
+verify the byte code, saves the deployment details to the registrar, and *then* create the Python
 contract object that corresponds to this address and return it.
 
 
@@ -282,7 +282,7 @@ Populus Configs Usage
 .. py:attribute:: proj_obj.config
 
     The merged ``project_config`` and ``user_config``: when ``project_config`` and ``user_config``
-    has the *same* key, the ``project_config`` overides ``user_config``, and the key value in the
+    has the *same* key, the ``project_config`` overrides ``user_config``, and the key value in the
     merged ``project.config`` will be that of ``project_config``
 
 
@@ -296,7 +296,7 @@ Populus Configs Usage
 
 .. py:attribute:: proj_obj.reload_config()
 
-    Reloads configuration from ``project.json`` and ``~/.populus/config.json``. You should instanciate the chain
+    Reloads configuration from ``project.json`` and ``~/.populus/config.json``. You should instantiate the chain
     objects after reload.
 
 
@@ -306,7 +306,7 @@ Assignment &  Persistency
 
 Populus initial configuration is loaded from the JSON files.
 
-You can customise the config keys in runtime, but these changes are *not* persisten and will *not* be saved. The next time
+You can customise the config keys in runtime, but these changes are *not* persistent and will *not* be saved. The next time
 Populus run, the configs will reset to ``project.json`` and ``~/.populus/config.json``.
 
 Assignment of simple values works like any dictionary:
@@ -337,13 +337,13 @@ Reset all changes back to the default:
 
     proj_obj.reload_config()
 
-You will have to re-instanciate chains after the reload.
+You will have to re-instantiate chains after the reload.
 
 .. note::
 
     JSON files may seem odd if you are used to
     Python settings files (like django), but we think that for blockchain development, the external,
-    static files are safer than a programmble Python module.
+    static files are safer than a programmable Python module.
 
 
 
@@ -352,7 +352,7 @@ JSON References
 '''''''''''''''
 
 There is a caveat: ``config_obj['foo.baz']`` may not return the same value is ``config_obj.get('foo.baz')``.
-The reasone is that the configuration files are loaded as JSON schema, which allows ``$ref$``.
+The reason is that the configuration files are loaded as JSON schema, which allows ``$ref$``.
 So if the config is:
 
 .. code-block:: javascript
@@ -375,14 +375,14 @@ Then:
    ['Basil','Sybil','Polly','Manual']
 
 To avoid this, if you assign your own config_obj, use ``config_obj.unref()``, which will solve
-all of the refernces.
+all of the references.
 
 
 Backends
 --------
 
-Populus is plugable, using backend. The interface is defined in a base class, and a
-backend can overide or implement part or all this functionality.
+Populus is pluggable, using backend. The interface is defined in a base class, and a
+backend can override or implement part or all this functionality.
 
 E.g., the default backend for the
 ``Registrar`` is the ``JSONFileBackend``, which saves the deployments details to a JSON file.

--- a/docs/gotchas.rst
+++ b/docs/gotchas.rst
@@ -16,7 +16,7 @@ E.g., suppose you want to calculate the average donation in a contract that coll
 The contract should only provide the total donations, and the number of donations, then calculate the average in the client code.
 
 [2] Everything the contract **stores** in it's persistent storage costs money, the gas.
-Try to minimise storage only to what absulutly positively is required for the contract to run. Data like derived calculations,
+Try to minimise storage only to what absolutely positively is required for the contract to run. Data like derived calculations,
 caching, aggregates etc, should be handled on the client.
 
 [3] Whenever possible, use **events and logs for persistent data**.
@@ -24,23 +24,23 @@ The logs are not accessible to the contract code, and are static, so you can't u
 But you can read the logs from the client, and they are much cheaper.
 
 [4] The pricing of contract **storage** is **not linear**.
-There is a high initial cost to setting the storage to non zero (touching the storage). Never reset and reintiate the storage.
+There is a high initial cost to setting the storage to non zero (touching the storage). Never reset and reinitiate the storage.
 
 [5] Everything the contracts uses for temporary memory costs money, the gas. The pricing of using **memory**, the part that is cleared once execution done (think RAM), is not linear either,
 and cost per the same unit of usage increases sharply once you used a lot of memory. Try to avoid unreasonable memory usage.
 
-[6] Even when you free storage, the gas you paid for that storage is **partially** refundble if. Don't use storage as a temporary store.
+[6] Even when you free storage, the gas you paid for that storage is **partially** refundable if. Don't use storage as a temporary store.
 
 [7] Each time you **deploy** a contract, it costs money, the gas.
-So the habbit of pushing the whole codebase after every small commit, can cost a lot of money.
-When possible, try to breakdown the functionality to small focused contracts. If you fix one, you don't have to re-deploy the others. Use library contracts (see below). Removing a contrat is partially refundble, but less than deployment.
+So the habit of pushing the whole codebase after every small commit, can cost a lot of money.
+When possible, try to breakdown the functionality to small focused contracts. If you fix one, you don't have to re-deploy the others. Use library contracts (see below). Removing a contract is partially refundable, but less than deployment.
 
-[8] No, sorry. Refunds will never exceed the gas provided in the transaction that initiated the refundble action. In fact,
-**refund is maxed to 50% of the gas** in that tansaction.
+[8] No, sorry. Refunds will never exceed the gas provided in the transaction that initiated the refundable action. In fact,
+**refund is maxed to 50% of the gas** in that transaction.
 
 [9] Whenever you just send money to a contract (a transaction with value > 0), **even without calling any function**,
 you run the contract's code.  The contract gets an opportunity to call other functions.
-Etheruem is different from Bitcoin: even simple money sending runs code
+Ethereum is different from Bitcoin: even simple money sending runs code
 (infact Bitcoin has a simple stack based scripts, but the common case is simple money transfers)
 
 [10] Every contract can have one un-named function, the fallback function,
@@ -67,7 +67,7 @@ to having a compiled executable without the source. When you compile with Populu
 The ABI tells the EVM how to correctly call the compiled bytecode and pad the arguments. Without it, there is no way to do it.
 **Don't loose the ABI**.
 
-[16] There is actually a bit convuluted way to call a contract without the ABI.  With the address ``call`` method
+[16] There is actually a bit convoluted way to call a contract without the ABI.  With the address ``call`` method
 it's possible to call the fallback function, just provide the arguments. It's also an easy way to call
 a contract if the fallback is the main function you work with. If the first argument of the ``call``
 is a ``byte4`` type, **this first argument is assumed to be a function signature**, and then arguments 2..n are given to this function
@@ -76,7 +76,7 @@ is a ``byte4`` type, **this first argument is assumed to be a function signature
 
 [17] When a contract sends money to another contract, **the called contract gets execution control** and can call your caller *before*
 it returns, and before you updated your state variables. This is a *re-entry attack*. Therefore, after this second call,
-your contract runs agian while the state variables do *not* reflect the already sent money.
+your contract runs again while the state variables do *not* reflect the already sent money.
 In other words: the callee can get the money, then call the sender in a state that does not tell that money was sent.
 To avoid it, always
 update the state variables that hold the amount which another account is allowed to get *before* you send money, and revert if the transaction failed.
@@ -131,7 +131,7 @@ Use the very fine grained Eth units instead.
 you will have to run your own fixed point calculations (many times you can retrieve the int variables, and run the decimal
 calculation on the client)
 
-[31] Once you unlock your acount in a running node, typically with geth, the running process has full access to your funds. Keep it
+[31] Once you unlock your account in a running node, typically with geth, the running process has full access to your funds. Keep it
 safe. **Unlock an account only in a local, protected instance**.
 
 [32] If you connect to a remote node with rpc, use it only for actions that do not require unlocking an account, such as reading logs,
@@ -146,7 +146,7 @@ Eth you need** for these actions.
 
 [36] If you use a password file to unlock the account, make sure the file is well protected with the **right permissions**.
 
-[37] If you look at your acount in sites like etherscan.io and there are funds in the account, yet localy the account
+[37] If you look at your account in sites like etherscan.io and there are funds in the account, yet locally the account
 balance is 0 and geth refuses to run actions that require funds for gas - then **your local node is not synced**. You must
 sync until the block with the transactions that sent money to this account.
 
@@ -162,7 +162,7 @@ but visibility is enforced in the bytecode and the exposed interface (this is no
 However, the scope visibility definitions have **no effect** on the
 information that the blockchain exposes to the outside world.
 
-[41] If you don't explicity set a ``payable`` modifier to a function, it will **reject the Eth that was sent in the transaction**.
+[41] If you don't explicitly set a ``payable`` modifier to a function, it will **reject the Eth that was sent in the transaction**.
 If no function has ``payable``, the contract can't accept Ether.
 
 [42] This **is** the answer.
@@ -173,9 +173,9 @@ in Python. You'll have to handle such lists yourself, if required.
 [44] The contract's Constructor runs only once **when the contract is created**, and can't be called again. The constructor is
 optional.
 
-[45] Inheritence in Solidity is different. Usually you have a Class, a Subclass, each is an independent object you can access.
-In Solidity, the inheritance is more syntatic. In the final compilation the compiler **copies the parent class members**,
-to create the bytecode of the derived contract with the *copied* memebers. In this context, ``private`` is just a notion of state variables and functions
+[45] Inheritance in Solidity is different. Usually you have a Class, a Subclass, each is an independent object you can access.
+In Solidity, the inheritance is more syntactic. In the final compilation the compiler **copies the parent class members**,
+to create the bytecode of the derived contract with the *copied* members. In this context, ``private`` is just a notion of state variables and functions
 that the compiler will *not* copy.
 
 [46] Memory reads are limited to a width of 256 bits, while writes can be either 8 bits or 256 bits wide
@@ -191,10 +191,10 @@ If a function type variable is not initialized, calling it will obviously result
 Deleting a local ``var`` variable that points to a state variable will except, since the "deleted" variable (the pointer)
 has no initial value to reset to.
 
-[51] Declared variables are implictly initiated to their **initial default** value at the begining of the function.
+[51] Declared variables are implicitly initiated to their **initial default** value at the beginning of the function.
 
-[52] You can declare a function as ``constant``, or the new term ``view``, which theoretaclly should declare a "safe"
-function that does not alter the state. Yet the compiler **does not enfore it.**
+[52] You can declare a function as ``constant``, or the new term ``view``, which theoretically should declare a "safe"
+function that does not alter the state. Yet the compiler **does not enforce it.**
 
 [53] ``internal`` functions can be called only from the contract itself.
 
@@ -205,20 +205,20 @@ don't need ``this`` (*this* is kinda bonus, no?)
 the compiler does not copy to the derived contracts. Otherwise, from within a contract, ``private`` is the same as ``internal``.
 
 [56] ``external`` is available only for functions. ``public``, ``internal`` and ``private`` are available for both functions
-and state variables. The **contract's interface** is built from it's ``external`` and ``public`` memebers.
+and state variables. The **contract's interface** is built from it's ``external`` and ``public`` members.
 
 [57] The compiler will **automatically** generate an accessor ("get" function) for the ``public`` state variables.
 
 [58] ``now`` is the time stamp of the **current block**
 
-[59] **Ethereum units** ``wei``, ``finney``, ``szabo`` or ``ether`` are reserved words, and can be used in experessions and literals.
+[59] **Ethereum units** ``wei``, ``finney``, ``szabo`` or ``ether`` are reserved words, and can be used in expressions and literals.
 
-[60] **Time units** ``seconds``, ``minutes``, ``hours``, ``days``, ``weeks`` and ``years``, are reserved words, and can be used in experessions and literals.
+[60] **Time units** ``seconds``, ``minutes``, ``hours``, ``days``, ``weeks`` and ``years``, are reserved words, and can be used in expressions and literals.
 
 [61] There is **no type conversion from non-boolean** to boolean types. ``if (1) { ... }`` is not valid Solidity.
 
 [62] The ``msg``, ``block`` and ``tx`` variables always exist in the **global namespace**, and you can use
-them and their members without any prior decleration or assignment
+them and their members without any prior declaration or assignment
 
 
 Nice! You got here.

--- a/docs/project.rst
+++ b/docs/project.rst
@@ -20,7 +20,7 @@ Basic Usage
 
 - ``Project(config_file_path=None)``
 
-When instantaited with no arguments, the project will look for a ``populus.json``
+When instantiated with no arguments, the project will look for a ``populus.json``
 file found in the current working directory and load that if found.
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-Welcom to Populus! Populus has (almost) everything you need for Ethereum blockchain development.
+Welcome to Populus! Populus has (almost) everything you need for Ethereum blockchain development.
 
 .. contents:: :local:
 
@@ -114,7 +114,7 @@ Ethereum developer. We use test blockchains, demo accounts, simple passwords, ev
 
 But once the code is ready for work and deployment with real Eth, you should be careful.
 As there is a clear difference between running your iOS app in the Xcode simulator to the real actions of the app on the iPhone,
-or to take another example, between running a website localy on 127.0.0.1 vs. running it on a real server which is opened to the entire
+or to take another example, between running a website locally on 127.0.0.1 vs. running it on a real server which is opened to the entire
 internet, there **is** a difference between blockchain development environment, and when you deploy and send real Eth.
 
 The core issue, as a developer, is that once you unlock an account, there is a running process with access to your Eth. Any mistake
@@ -130,7 +130,7 @@ the Ether you need it for, from time to time.
 
 [2] Never unlock a real Ether account on a remote node. You can use a remote node, but not for actions
 that require an unlocked account. When you unlock an account on a remote node, anybody with access
-to the node has access to your funds. In other words, the geth instance that unlocked your acount
+to the node has access to your funds. In other words, the geth instance that unlocked your account
 should run on your local protected machine.
 
 [3] Geth allows you to provide a password file, which is handy (more on it later). The password file should be
@@ -177,7 +177,7 @@ that is generated as part of the project initialization.
 
 .. note::
 
-    Check your IDE for Solidity extention/package.
+    Check your IDE for Solidity extension/package.
 
 
 Here is the contract:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -50,7 +50,7 @@ Release Notes
 1.11.2
 ------
 
-- Bugfix for running tests without explicitely declared project root dir.
+- Bugfix for running tests without explicitly declared project root dir.
 
 
 
@@ -67,11 +67,11 @@ Release Notes
 1.11.0
 ------
 
-- Update to confguration API to support both *project* level configuration files as well as *user* level configuration files.
+- Update to configuration API to support both *project* level configuration files as well as *user* level configuration files.
 - ``--wait-for-sync`` cli argument in ``$ populus deploy`` now defaults to ``False`` (previous defaulted to ``True``)
 - Deprecation of Go-Ethereum based ``Chain`` objects in preparation for upcoming *Environments* API which will replace the *Chain* API.
 - New ``$ populus chain new`` command for initializing local development chains.
-- Removal of ``$ populus config set`` and ``$ populus config delete`` CLI comands.
+- Removal of ``$ populus config set`` and ``$ populus config delete`` CLI commands.
 
 
 .. _v1.10.3-release-notes:
@@ -106,7 +106,7 @@ Release Notes
 - Support for running populus commands from outside of the project directory with ``-p/--project``.
 - Deprecate support for ``solc<0.4.11``.
 - Deprecate ``Project.write_config()`` in preparation for configuration API refactors.
-- Deprecate ``$ populus config set`` and ``populus config delete`` commands in preparatin for configuration API refactors.
+- Deprecate ``$ populus config set`` and ``populus config delete`` commands in preparation for configuration API refactors.
 
 
 
@@ -127,7 +127,7 @@ Release Notes
 - Bugfix for ``SolcStandardJSONBacken`` compilation.  Settings for this
   compiler now appropriately split between standard JSON input and compiler
   command line arguments.
-- Deprecate: ``project.contracts_source_dir`` and releated setting
+- Deprecate: ``project.contracts_source_dir`` and related setting
   ``compilation.contracts_source_dir``.
 - New API: ``project.contracts_source_dirs`` replaces deprecated singular
   ``project.contracts_source_dir``.
@@ -171,7 +171,7 @@ Release Notes
 - Remove deprecated ``project.build_dir`` API
 - Remove deprecated ``project.compiled_contracts`` API
 - Remove deprecated ``project.blockchains_dir`` API
-- Remove deprecated ``project.get_blockahin_data_dir`` API
+- Remove deprecated ``project.get_blockchain_data_dir`` API
 - Remove deprecated ``project.get_blockchain_chaindata_dir`` API
 - Remove deprecated ``project.get_blockchain_dapp_dir`` API
 - Remove deprecated ``project.get_blockchain_ipc_path`` API
@@ -357,7 +357,7 @@ This is the first release of populus that should be considered stable.
 - Switch to ``web3.py`` for all blockchain interactions.
 - Compilation:
   - Remove filtering.  Compilation now always compiles all contracts.
-  - Compilation now runs with optimization turned on by default.  Can be disabled with ``--no-optimizie``.
+  - Compilation now runs with optimization turned on by default.  Can be disabled with ``--no-optimize``.
   - Remove use of  ``./project-dir/libraries`` directory.  All contracts are now expected to reside in the ``./project-dir/contracts`` directory.
 - New ``populus.Project`` API.
 - New Migrations API:
@@ -365,9 +365,9 @@ This is the first release of populus that should be considered stable.
   - ``$ populus makemigration`` for creating migration files.
   - ``$ populus migrate`` for executing migrations.
 - New configuration API:
-  - New commands ``$ populus config``, ``$ populus config:set`` and ``$ populus config:unset`` for managing configuratino.
+  - New commands ``$ populus config``, ``$ populus config:set`` and ``$ populus config:unset`` for managing configuration.
 - New Chain API:
-  - Simple programatic running of project chains.
+  - Simple programmatic running of project chains.
   - Access to ``web3.eth.contract`` objects for all project contracts.
   - Access to pre-linked code based on previously deployed contracts.
 
@@ -422,7 +422,7 @@ This is the first release of populus that should be considered stable.
 -----
 
 - When a contract function call that is supposed to return data returns no data
-  an error was thown.  Now a custom exception is thrown.  This is a breaking
+  an error was thrown.  Now a custom exception is thrown.  This is a breaking
   change as previously for addresses this would return the empty address.
 
 0.6.6

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -9,18 +9,18 @@ Introduction to Ethereum
 
 * `A 101 Noob Intro to Programming Smart Contracts on Ethereum <https://medium.com/@ConsenSys/a-101-noob-intro-to-programming-smart-contracts-on-ethereum-695d15c1dab4>`_, from Consensys
 
-* `A Gentle Intorduction to Ethereum <https://bitsonblocks.net/2016/10/02/a-gentle-introduction-to-ethereum/>`_, from bitsonblocks
+* `A Gentle Introduction to Ethereum <https://bitsonblocks.net/2016/10/02/a-gentle-introduction-to-ethereum/>`_, from bitsonblocks
 
 How the Platform Works
 ----------------------
 
-* `The Etherum Whitepaper <https://github.com/ethereum/wiki/wiki/White-Paper>`_, by Vitalik Buterin
+* `The Ethereum Whitepaper <https://github.com/ethereum/wiki/wiki/White-Paper>`_, by Vitalik Buterin
 
 * `The Bitcoin Book <https://github.com/bitcoinbook/bitcoinbook>`_ (Some of the Bitcoin concepts are different in Ethereum, but in any case it's useful to understand the difference)
 * `Even more subtleties <https://github.com/ethereum/wiki/wiki/Subtleties>`_
 
 
-Protecting Yout Ether
+Protecting Your Ether
 ---------------------
 * `Protecting yourself and your funds, from MyEtherWallet <https://myetherwallet.github.io/knowledge-base/getting-started/protecting-yourself-and-your-funds.html>`_
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -95,7 +95,7 @@ The precedence order for these different methods of setting the project director
 
 .. note:
 
-    Providing only the propulus project arg (via command line, or pytest.ini, or the environment variable) will not replace
+    Providing only the populus project arg (via command line, or pytest.ini, or the environment variable) will not replace
     py.test own tests finding. So you still need to provide pytest the correct tests directory, or rely on pytest tests
     collecting.
 
@@ -103,7 +103,7 @@ The precedence order for these different methods of setting the project director
     may not work if you run it say from /home/elsewhere. The argument will only tell pytest where to load the project fixture, but
     not where the actual tests are.
 
-    The nice thing is that you can run the same tests suite on diffrent projects, each time apply the same test to another project,
+    The nice thing is that you can run the same tests suite on different projects, each time apply the same test to another project,
     where pytest will load the project fixture from another project.
 
 

--- a/docs/tutorial.part-2.rst
+++ b/docs/tutorial.part-2.rst
@@ -15,7 +15,7 @@ to the blockchain.
 
 One of the nice things about Ethereum is the *protocol*, a protocol which specifies how to run a blockchain.
 Theoretically, you can use this exact protocol to run your own blockchain, which is private and totally
-seprated from the mainnet Ethereum blockchain and it's nodes.
+separated from the mainnet Ethereum blockchain and it's nodes.
 
 Although the private Ether you will mint in this private blockchain are not worth a lot in the outside world
 (but who knows?), such private, local blockchain is a great tool for development. It simulates
@@ -115,9 +115,9 @@ Here, populus saved the password in a password file:
 The default password we used, tells. It's designated for development and testing, not when using real Eth.
 
 Why to save the password in a file *at all*? Because you can provide this file path
-to geth with the ``password`` commnad line argument. Otherwise, you will have to manually enter
+to geth with the ``password`` command line argument. Otherwise, you will have to manually enter
 the password each time geth starts. Moreover, sometimes it's hard to spot the password prompt
-with all the info that geth spits. So a password file is more convinient, but obviously should be fully secured,
+with all the info that geth spits. So a password file is more convenient, but obviously should be fully secured,
 with the right permissions.
 
 .. _tutorial_accounts:
@@ -128,11 +128,11 @@ Accounts
 Populus created the account for you, but you can create more accounts with ``$ geth account new``. You can keep
 as many wallets as you want in the keystore. One wallet, which you can set, is the primary default account, called
 "etherbase" or "coinbase". You can use any wallet you save in the keystore, as long as you have the password to unlock it.
-See `geth accounts managment <https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts>`_ .
+See `geth accounts management <https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts>`_ .
 
 .. note::
 
-   The terms "create an account", or "new account", may be missleading. Nobody "creates" an account,
+   The terms "create an account", or "new account", may be misleading. Nobody "creates" an account,
    since all the possible alphanumeric combinations of a valid Ethereum account address are already "out there".
    But any combination is useless, if you don't have the
    private key for this particular combination. "Create" an account means to start with a private key,
@@ -180,7 +180,7 @@ is that you can mint money quite easily! So the genesis block allocates to the d
 Think of it as monopoly money: it looks like real money, it behaves like real money, but it will not get you much in the grocery store.
 However, this local chain Eth is very handy for development and testing.
 
-.. _runing_local_blockchain:
+.. _running_local_blockchain:
 
 Running the Local Blockchain
 ----------------------------

--- a/docs/tutorial.part-3.rst
+++ b/docs/tutorial.part-3.rst
@@ -68,7 +68,7 @@ copy-paste the path from the ``run_chain.sh`` script in the ``chains/horton/`` d
   based configuration see `JSON Schema <http://json-schema.org/>`_.
 
 Note the line ``{"$ref": "contracts.backends.JSONFile"}``. There is a ``$ref``, but the reference
-key does not exist in the file. This is beacuase the ``project.json`` config file is *complementary*
+key does not exist in the file. This is because the ``project.json`` config file is *complementary*
 to the main populus user-scope config file, at ``~/.populus/config.json``. The user config holds
 for all your populus projects, and you can use the ``project.json`` just for the configuration changes
 that you need for a specific project. Thus, you can ``$ref`` the user-config keys in any project configuration file.
@@ -132,5 +132,5 @@ Well done!
   We used here ``--no-wait-for-sync``, since the account has (a lot of) Eth from the get go, allocated
   in the genesis block. However, if you work with testnet or mainnet, you must sync at least until the block
   with the transactions that sent some Eth to the account you are deploying from. Otherwise, your local geth will not know
-  that there is Eth in the account to pay for the gas. Once the chain is synced, you can deploy immidiatly.
+  that there is Eth in the account to pay for the gas. Once the chain is synced, you can deploy immediately.
 

--- a/populus/api/upgrade.py
+++ b/populus/api/upgrade.py
@@ -47,7 +47,7 @@ def upgrade_configs(project_dir, logger, to_version):
 
         if int(legacy_version) > int(LAST_NO_USER_CONFIG_VERSION):
             raise KeyError(
-                "Unkown legacy version {legacy_version} at {legacy_config}".format(
+                "Unknown legacy version {legacy_version} at {legacy_config}".format(
                     legacy_version=legacy_version,
                     legacy_config=legacy_config
                 )

--- a/populus/chain/geth.py
+++ b/populus/chain/geth.py
@@ -56,9 +56,9 @@ class LoggedDevGethProcess(LoggingMixin, DevGethProcess):
         )
 
 
-class LoggedTestnetGethProccess(LoggingMixin, TestnetGethProcess):
+class LoggedTestnetGethProcess(LoggingMixin, TestnetGethProcess):
     def __init__(self, project_dir, geth_kwargs):
-        super(LoggedTestnetGethProccess, self).__init__(
+        super(LoggedTestnetGethProcess, self).__init__(
             geth_kwargs=geth_kwargs,
         )
 
@@ -166,7 +166,7 @@ class TemporaryGethChain(BaseGethChain):
 
 class TestnetChain(BaseGethChain):
     def get_geth_process_instance(self):
-        return LoggedTestnetGethProccess(
+        return LoggedTestnetGethProcess(
             project_dir=self.project.project_dir,
             geth_kwargs=self.geth_kwargs,
         )

--- a/populus/config/upgrade/v4.py
+++ b/populus/config/upgrade/v4.py
@@ -64,7 +64,7 @@ def upgrade_v4_to_v5(v4_config):
 
     upgraded_v4_config = copy.deepcopy(v4_config)
 
-    # new configuration values whos keys were not present in the previous
+    # new configuration values whose keys were not present in the previous
     # configuration.
     for key_path in NEW_V5_PATHS:
         if has_nested_key(upgraded_v4_config, key_path):

--- a/populus/config/upgrade/v5.py
+++ b/populus/config/upgrade/v5.py
@@ -53,7 +53,7 @@ def upgrade_v5_to_v6(v5_config):
 
     upgraded_v5_config = copy.deepcopy(v5_config)
 
-    # new configuration values whos keys were not present in the previous
+    # new configuration values whose keys were not present in the previous
     # configuration.
     for key_path in NEW_V6_PATHS:
         if has_nested_key(upgraded_v5_config, key_path):

--- a/populus/utils/chains.py
+++ b/populus/utils/chains.py
@@ -20,8 +20,8 @@ BASE_BLOCKCHAIN_STORAGE_DIR = "./chains"
 
 @normpath
 def get_base_blockchain_storage_dir(project_dir):
-    base_blochcain_storage_dir = os.path.join(project_dir, BASE_BLOCKCHAIN_STORAGE_DIR)
-    return base_blochcain_storage_dir
+    base_blockchain_storage_dir = os.path.join(project_dir, BASE_BLOCKCHAIN_STORAGE_DIR)
+    return base_blockchain_storage_dir
 
 
 BLOCK_OR_TRANSACTION_HASH_REGEX = "^(?:0x)?[a-zA-Z0-9]{64}$"

--- a/populus/utils/linking.py
+++ b/populus/utils/linking.py
@@ -25,7 +25,7 @@ DEPENDENCY_RE = (
 
 
 # start and length should be `byte` offsets meaning they represent the
-# start/length in the bytecode in its bytes representation.  To transate to hex
+# start/length in the bytecode in its bytes representation.  To translate to hex
 # representation, these two numbers should be multiplied by two.
 def LinkReference(source_path, name, start, length):
     return {
@@ -77,7 +77,7 @@ def find_placeholder_locations(bytecode):
 
 def expand_placeholder(placeholder, full_names):
     """
-    Link references whos names are longer than their bytecode representations
+    Link references whose names are longer than their bytecode representations
     will get truncated to 4 characters short of their full name because of the
     double underscore prefix and suffix.  This embedded string is referred to
     as the `placeholder`
@@ -153,7 +153,7 @@ def insert_link_value(bytecode, value, offset):
 def link_bytecode(bytecode, link_reference_values):
     """
     Given the bytecode for a contract, and it's dependencies in the form of
-    {contract_name: address} this functino returns the bytecode with all of the
+    {contract_name: address} this function returns the bytecode with all of the
     link references replaced with the dependency addresses.
 
     TODO: validate that the provided values are of the appropriate length

--- a/populus/utils/observers.py
+++ b/populus/utils/observers.py
@@ -23,7 +23,7 @@ def get_observer_for_platform(platform):
         return WindowsAPIObserver
     else:
         raise ValueError(
-            "Unsupported platfom '{0}'.  Must be one of 'win32', 'cgwin', "
+            "Unsupported platform '{0}'.  Must be one of 'win32', 'cgwin', "
             "'linux*', 'darwin'"
         )
 

--- a/tests/compilation/test_solc_combined_json_backend.py
+++ b/tests/compilation/test_solc_combined_json_backend.py
@@ -93,7 +93,7 @@ def test_compiling_with_abstract_contract(project):
 
 @load_contract_fixture('Abstract.sol')
 @load_contract_fixture('UsesAbstract.sol')
-def test_compiling_with_abstract_contract_inhereted(project):
+def test_compiling_with_abstract_contract_inherited(project):
     _, compiled_contracts = compile_project_contracts(project)
 
     assert 'Abstract' in compiled_contracts

--- a/tests/compilation/test_solc_standard_json_backend.py
+++ b/tests/compilation/test_solc_standard_json_backend.py
@@ -82,7 +82,7 @@ def test_compiling_with_abstract_contract(project):
 
 @load_contract_fixture('Abstract.sol')
 @load_contract_fixture('UsesAbstract.sol')
-def test_compiling_with_abstract_contract_inhereted(project):
+def test_compiling_with_abstract_contract_inherited(project):
     _, compiled_contracts = compile_project_contracts(project)
 
     assert 'Abstract' in compiled_contracts

--- a/tests/mapping-utils/test_deep_merge_dicts.py
+++ b/tests/mapping-utils/test_deep_merge_dicts.py
@@ -17,7 +17,7 @@ def test_deep_merge_with_multiple_args():
     assert expected == actual
 
 
-def test_deep_merge_orger_precidence():
+def test_deep_merge_order_precedence():
     assert deep_merge_dicts({'a': 1, 'b': 2}, {'b': 3, 'c': 4}) == {'a': 1, 'b': 3, 'c': 4}
 
 


### PR DESCRIPTION
### What was wrong?
I started reading the docs and one of the first words in Quickstart had a typo (`Welcom`). I noticed a few more in that first page alone and decided to take a look at the rest of the project.

### How was it fixed?
Typing.
