### PR TITLE
Fix out of context doc text.

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -150,8 +150,7 @@ Web3
 
 * ``web3``
 
-Convenience fixture for the ``chain.provider`` property.  A Web3.py instance
-configured to connect to ``chain`` fixture.
+A Web3.py instance configured to connect to ``chain`` fixture.
 
 .. code-block:: python
 


### PR DESCRIPTION
### What was wrong?
Docs were inconsistent. Probably a copy/paster error.


### How was it fixed?
Remove irrelevant text.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/62378/36062925-6cbd2ac8-0e6d-11e8-9252-2df1af2b0e6a.png)
