### PR TITLE
Rename Viper => Vyper as per upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,9 @@ matrix:
       env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     - python: "3.6"
       env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py36"
-    # Viper
+    # Vyper
     - python: "3.6"
-      env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py36" INSTALL_VIPER="true"
+      env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py36" INSTALL_VYPER="true"
     # Linting
     - python: "3.5"
       env: TOX_POSARGS="-e flake8"
@@ -108,8 +108,8 @@ install:
   - if [ -n "$GETH_VERSION" ]; then travis_retry pip install "py-geth>=1.9.0"; fi
   - if [ -n "$GETH_VERSION" ]; then python -m geth.install $GETH_VERSION; fi
   - if [ -n "$GETH_VERSION" ]; then export GETH_BINARY="$GETH_BASE_INSTALL_PATH/geth-$GETH_VERSION/bin/geth"; fi
-  # install viper if necessary.
-  - if [ -n "$INSTALL_VIPER"]; then pip install https://github.com/ethereum/viper/archive/master.zip; fi
+  # install vyper if necessary.
+  - if [ -n "$INSTALL_VYPER"]; then pip install https://github.com/ethereum/vyper/archive/master.zip; fi
   # package
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Contents
     resources
     modules
     release
-    viper_support
+    vyper_support
 
 
 Indices and tables

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,7 +24,7 @@ Release Notes
 2.0.2
 -----
 
-- Added experimental Viper support.
+- Added experimental Vyper support.
 
 
 .. _v2.0.1-release-notes:

--- a/docs/viper_support.rst
+++ b/docs/viper_support.rst
@@ -1,14 +1,14 @@
-Viper Support
+Vyper Support
 =============
 
-Populus has support for the `viper <https://github.com/ethereum/viper>`_
-compiler. Viper is a python-like experimental programming language.
+Populus has support for the `vyper <https://github.com/ethereum/vyper>`_
+compiler. Vyper is a python-like experimental programming language.
 
 
 Known limitations
 -----------------
 
-Viper requires Python 3.6 or above.
+Vyper requires Python 3.6 or above.
 
 
 Installation
@@ -19,19 +19,19 @@ To install the compiler:
 
 .. code-block:: shell
 
-   pip install https://github.com/ethereum/viper/archive/master.zip
+   pip install https://github.com/ethereum/vyper/archive/master.zip
 
 
-You will see the `viper` binary is now installed.
+You will see the `vyper` binary is now installed.
 
 
 .. code-block:: shell
 
-    $ viper
-    usage: viper [-h] [-f {abi,json,bytecode,bytecode_runtime,ir}]
+    $ vyper
+    usage: vyper [-h] [-f {abi,json,bytecode,bytecode_runtime,ir}]
                  [--show-gas-estimates]
                  input_file
-    viper: error: the following arguments are required: input_file
+    vyper: error: the following arguments are required: input_file
 
 
 Using
@@ -49,15 +49,15 @@ Place a `backend` key in the `compilation` section, as shown below:
             "contracts_source_dirs": ["./contracts"],
             "import_remappings": [],
             "backend": {
-                "class": "populus.compilation.backends.ViperBackend"
+                "class": "populus.compilation.backends.VyperBackend"
             }
         }
     }
 
 
-This will set the Populus framework to only pick up Viper contracts in the
+This will set the Populus framework to only pick up Vyper contracts in the
 configured contracts directories.
-Now that everything is configured you can create a Viper greeter contract:
+Now that everything is configured you can create a Vyper greeter contract:
 
 
 .. code-block:: python

--- a/populus/compilation/backends/__init__.py
+++ b/populus/compilation/backends/__init__.py
@@ -7,6 +7,6 @@ from.solc_standard_json import (  # noqa: F401
 from .solc_auto import (  # noqa: F401
     SolcAutoBackend,
 )
-from .viper import (  # noqa: F401
-    ViperBackend,
+from .vyper import (  # noqa: F401
+    VyperBackend,
 )

--- a/populus/compilation/backends/vyper.py
+++ b/populus/compilation/backends/vyper.py
@@ -6,16 +6,16 @@ from .base import (
 )
 
 
-class ViperBackend(BaseCompilerBackend):
+class VyperBackend(BaseCompilerBackend):
     project_source_glob = ('*.v.py', '*.vy')
     test_source_glob = ('test_*.v.py', 'test_*.vy')
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         try:
-            from viper import compiler
+            from vyper import compiler
         except ImportError:
             raise ImportError(
-                'viper needs to be installed to use ViperBackend' +
+                'vyper needs to be installed to use VyperBackend' +
                 ' as compiler backend.'
             )
 

--- a/populus/utils/testing.py
+++ b/populus/utils/testing.py
@@ -79,9 +79,9 @@ def link_bytecode_by_name(bytecode, link_references, **link_names_and_values):
     return linked_bytecode
 
 
-def viper_installed():
+def vyper_installed():
     try:
-        import viper  # noqa: F401
+        import vyper  # noqa: F401
         return True
     except ImportError:
         return False

--- a/tests/compilation/test_viper_backend.py
+++ b/tests/compilation/test_viper_backend.py
@@ -8,20 +8,20 @@ from populus.compilation import (
 
 from populus.utils.testing import (
     load_contract_fixture,
-    viper_installed,
+    vyper_installed,
 )
 
 
 pytestmark = pytest.mark.skipif(
-    not viper_installed(),
-    reason="Viper compiler not installed",
+    not vyper_installed(),
+    reason="Vyper compiler not installed",
 )
 
 
 @load_contract_fixture('Greeter.vy')
-def test_compiling_viper_project_contracts(project):
+def test_compiling_vyper_project_contracts(project):
     project.config['compilation']['backend'] = {
-        'class': 'populus.compilation.backends.ViperBackend',
+        'class': 'populus.compilation.backends.VyperBackend',
     }
     source_paths, compiled_contracts = compile_project_contracts(project)
 

--- a/tests/compile-utils/test_find_viper_source_files.py
+++ b/tests/compile-utils/test_find_viper_source_files.py
@@ -10,7 +10,7 @@ from populus.utils.filesystem import (
 def test_gets_correct_files_default_dir(project_dir, write_project_file):
     project = Project(project_dir)
     project.config['compilation']['backend'] = {
-        'class': 'populus.compilation.backends.ViperBackend',
+        'class': 'populus.compilation.backends.VyperBackend',
     }
 
     compiler_backend = project.get_compiler_backend()

--- a/tests/fixtures/Greeter.vy
+++ b/tests/fixtures/Greeter.vy
@@ -1,4 +1,4 @@
-# Viper Greeter Contract
+# Vyper Greeter Contract
 
 greeting: bytes <= 20
 


### PR DESCRIPTION
### What was wrong?

The package for the Vyper programming language is no longer called viper.

Although an import alias seems to exist for viper => vyper, I was getting package import errors with populus `master` and vyper `master`.

### How was it fixed?

All instances of the word viper were changed to vyper, which fixes the package imports.

#### Cute Animal Picture

![](http://maxpixel.freegreatpicture.com/static/photo/2x/Aggressive-Viper-Water-Moccasin-Crocs-Snake-Mouth-1332381.jpg)
