### PR TITLE
Add documentation for chain.contracts

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -170,8 +170,8 @@ Individual Chain Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each key and value in the ``chains`` portion of the configuration corresponds
-to the name of the chain and the settings for that chain.  Each chain has two
-primary sections, ``web3`` and ``chain`` configuration settings.
+to the name of the chain and the settings for that chain.  Each chain has three
+primary sections, ``web3``, ``chain``, and ``contracts`` configuration settings.
 
 .. code-block:: javascript
 
@@ -184,6 +184,14 @@ primary sections, ``web3`` and ``chain`` configuration settings.
           "web3": {
             "provider": {
               "class": "web3.providers.ipc.IPCProvider"
+            }
+          },
+          "contracts": {
+            "backends": {
+              "JSONFile": {"$ref": "contracts.backends.JSONFile"},
+              "ProjectContracts": {
+                "$ref": "contracts.backends.ProjectContracts"
+              }
             }
           }
         }


### PR DESCRIPTION

### What was wrong?

Previously the "chains.contracts" config value was not documented, causing user confusion (see https://github.com/ethereum/populus/issues/367). 

### How was it fixed?

Add a bit of sample config to help new users to avoid broken configurations.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/18148490/36330271-d8a04c5c-131d-11e8-92d0-0f5b6d168198.png)
