### PR TITLE
add polus --version option

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -20,8 +20,11 @@ Command Line Options
       Populus
 
     Options:
-      -p, --project DIRECTORY  Specify a populus project directory to be used.
-      -h, --help             Show this message and exit.
+      -p, --project PATH  Specify a populus project directory
+      -l, --logging TEXT  Specify the logging level.  Allowed values are
+                          DEBUG/INFO or their numeric equivalents 10/20
+      -v, --version       Show the version and exit.
+      -h, --help          Show this message and exit.
 
     Commands:
       chain          Manage and run ethereum blockchains.

--- a/populus/cli/main.py
+++ b/populus/cli/main.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import warnings
+import pkg_resources
 
 import click
 
@@ -58,6 +59,12 @@ def validate_logging_level(ctx, param, value):
     ),
     default=str(logging.INFO),
     callback=validate_logging_level,
+)
+@click.version_option(
+    pkg_resources.get_distribution("populus").version,
+    '--version',
+    '-v',
+    message='%(version)s',
 )
 @click.pass_context
 def main(ctx, project_dir, logging_level):


### PR DESCRIPTION
### What was wrong?

Impossible to know what populus version one is running by running the command. See #325 

### How was it fixed?

New command line option -v/--version and documentation update.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/26160778/36345542-cddfc940-142c-11e8-9877-ddece279844a.png)

