### PR TITLE
Add missing populus command in tutorial

### DIFF
--- a/docs/tutorial.part-3.rst
+++ b/docs/tutorial.part-3.rst
@@ -96,7 +96,7 @@ Finally, deploy the contract:
 
 .. code-block:: bash
 
-  $ deploy --chain horton Greeter --no-wait-for-sync
+  $ populus deploy --chain horton Greeter --no-wait-for-sync
 
   > Found 1 contract source files
     - contracts/Greeter.sol


### PR DESCRIPTION
### What was wrong?
The command for deploying the greeter contract in the tutorial was missing the `populus` command


### How was it fixed?
added `populus` command


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/15894818/36623768-8594151c-18bc-11e8-8150-27a3e712da82.png)
