### PR TITLE
Fix spelling error

### DIFF
--- a/populus/utils/linking.py
+++ b/populus/utils/linking.py
@@ -153,7 +153,7 @@ def insert_link_value(bytecode, value, offset):
 def link_bytecode(bytecode, link_reference_values):
     """
     Given the bytecode for a contract, and it's dependencies in the form of
-    {contract_name: address} this functino returns the bytecode with all of the
+    {contract_name: address} this function returns the bytecode with all of the
     link references replaced with the dependency addresses.
 
     TODO: validate that the provided values are of the appropriate length


### PR DESCRIPTION
### What was wrong?
The spelling of the word `function` was wrong in a docstring.


### How was it fixed?
`functino` changed to `function` :+1: 


#### Cute Animal Picture

> put a cute animal picture here.

![](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals-2/cute-baby-animals-2-2.jpg)
