### PR TITLE
Fixes #434 : Add shebang line to the init_chain and run_chain scripts

### DIFF
--- a/populus/api/utils.py
+++ b/populus/api/utils.py
@@ -38,6 +38,8 @@ RUN_COMMAND = (
     "--password {password_path} --nodiscover --mine --minerthreads 1 "
 )
 
+SHEBANG = '#!/bin/sh'
+
 GENESIS_BLOCK = '''
 {
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -95,6 +97,8 @@ def new_local_chain(project_dir, chain_name):
     )
     init_geth_path = os.path.join(chain_dir, 'init_chain.sh')
     with open(init_geth_path, 'w+') as f:
+        f.write(SHEBANG)
+        f.write('\n')
         f.write(init)
     chmod_plus_x(init_geth_path)
 
@@ -106,5 +110,7 @@ def new_local_chain(project_dir, chain_name):
     )
     run_geth_path = os.path.join(chain_dir, 'run_chain.sh')
     with open(run_geth_path, 'w+') as f:
+        f.write(SHEBANG)
+        f.write('\n')
         f.write(run)
     chmod_plus_x(run_geth_path)


### PR DESCRIPTION
### What was wrong?

User reported following error via issue #434 
```
Failed to execute process './init_chain.sh'. Reason:
exec: Exec format error
The file './init_chain.sh' is marked as an executable but could not be run by the operating system.
```
### How was it fixed?

Added `#!/bin/sh` as a first line to these two scripts

#### Cute Animal Picture

```
                / \
                / _ \
               | / \ |
               ||   || _______
               ||   || |\     \
               ||   || ||\     \
               ||   || || \    |
               ||   || ||  \__/
               ||   || ||   ||
                \\_/ \_/ \_//
               /   _     _   \
              /               \
              |    O     O    |
              |   \  ___  /   |                           
             /     \ \_/ /     \
            /  -----  |  --\    \
            |     \__/|\__/ \   |
            \       |_|_|       /
             \_____       _____/
                   \     /
```
