### PR TITLE
made wait settings configurable through project.json

### DIFF
--- a/populus/chain/base.py
+++ b/populus/chain/base.py
@@ -91,7 +91,7 @@ class BaseChain(object):
 
     @property
     def wait(self):
-        return Wait(self.web3)
+        return Wait(self.web3, **self.config.wait_settings)
 
     #
     # +--------------+

--- a/populus/config/chain.py
+++ b/populus/config/chain.py
@@ -53,6 +53,10 @@ class ChainConfig(Config):
         else:
             raise ValueError(UNSUPPORTED_CHAIN_IDENTIFIER_MSG.format(chain_identifier))
 
+    @property
+    def wait_settings(self):
+        return self.get('chain.wait.settings', {})
+
     def get_web3_config(self):
         return self.get_config('web3', config_class=Web3Config)
 

--- a/tests/config-objects/test_chain_config_object.py
+++ b/tests/config-objects/test_chain_config_object.py
@@ -1,5 +1,7 @@
-import pytest
+import random
+import sys
 
+import pytest
 from web3.providers.ipc import IPCProvider
 
 from populus.chain import (
@@ -107,3 +109,28 @@ def test_is_external_property():
     assert chain_config.is_external is False
     chain_config.set_chain_class('external')
     assert chain_config.is_external is True
+
+
+def test_chain_wait_settings(project):
+    timeout = random.randint(0, sys.maxsize)
+    poll_interval = random.randint(0, sys.maxsize)
+    chain_config = ChainConfig({
+        'chain': {
+            'class': 'populus.chain.external.ExternalChain',
+            'wait': {
+                'settings': {
+                    'timeout': timeout,
+                    'poll_interval': poll_interval
+                }
+            }
+        },
+        'web3': {
+            'provider': {
+                'class': 'web3.providers.ipc.IPCProvider'
+            }
+        },
+    })
+    chain = chain_config.get_chain(project, 'test-chain')
+    with chain as running_chain:
+        assert running_chain.wait.timeout == timeout
+        assert running_chain.wait.poll_interval == poll_interval


### PR DESCRIPTION
### What was wrong?

Arguments of `wait` weren't configurable. This causes problems when contracts take longer to deploy than the hardcoded timeout in populus.

### How was it fixed?
Allowed passing `chain.wait.settings` as shown below
```json
{
        "chain": {
            "class": "populus.chain.external.ExternalChain",
            "wait": {
                "settings": {
                    "timeout": 300,
                    "poll_interval": 2
                }
            }
        },
        "web3": {
            "provider": {
                "class": "web3.providers.ipc.IPCProvider"
            }
        },
}
```


#### Cute Animal Picture

![](https://out.reddit.com/t3_8r7ly5?url=https%3A%2F%2Fi.imgur.com%2FKhA8JDM.jpg&token=AQAA6-IjW_BKSmsBFhLjhXp6mbuLQdtfi4Lcar5lIiohYauRTTTY&app_name=desktop2x&user_id=75643903649)
