### PR TITLE
feature/465 drop support for python27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,50 +11,36 @@ env:
 matrix:
   include:
     # Solc 0.4.13
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.14
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.15
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.16
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.17
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.18
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.19
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"

--- a/populus/api/deploy.py
+++ b/populus/api/deploy.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 import time

--- a/populus/chain/base.py
+++ b/populus/chain/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from pylru import lrucache
 

--- a/populus/chain/geth.py
+++ b/populus/chain/geth.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import warnings

--- a/populus/cli/config_cmd.py
+++ b/populus/cli/config_cmd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/compilation/__init__.py
+++ b/populus/compilation/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 import logging

--- a/populus/compilation/backends/solc_auto.py
+++ b/populus/compilation/backends/solc_auto.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from semantic_version import (
     Spec,

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import pprint
 import warnings

--- a/populus/compilation/backends/vyper.py
+++ b/populus/compilation/backends/vyper.py
@@ -12,7 +12,7 @@ class VyperBackend(BaseCompilerBackend):
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         try:
-            from vyper import compiler
+            from .vyper import compiler
         except ImportError:
             raise ImportError(
                 'vyper needs to be installed to use VyperBackend' +

--- a/populus/config/backend.py
+++ b/populus/config/backend.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from populus.utils.module_loading import (
     import_string,

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -141,7 +141,7 @@ class Config(object):
     def __bool__(self):
         return bool(self._wrapped)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.__bool__()
 
     def __len__(self):

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -141,7 +141,7 @@ class Config(object):
     def __bool__(self):
         return bool(self._wrapped)
 
-    def __bool__(self):
+    def __nonzero__(self):
         return self.__bool__()
 
     def __len__(self):

--- a/populus/config/compiler.py
+++ b/populus/config/compiler.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     is_string,

--- a/populus/config/upgrade/__init__.py
+++ b/populus/config/upgrade/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 import enum
 import pprint
 

--- a/populus/config/upgrade/v1.py
+++ b/populus/config/upgrade/v1.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v2.py
+++ b/populus/config/upgrade/v2.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v3.py
+++ b/populus/config/upgrade/v3.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import itertools

--- a/populus/config/upgrade/v4.py
+++ b/populus/config/upgrade/v4.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import itertools

--- a/populus/config/upgrade/v5.py
+++ b/populus/config/upgrade/v5.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v6.py
+++ b/populus/config/upgrade/v6.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 

--- a/populus/config/upgrade/v7.py
+++ b/populus/config/upgrade/v7.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 

--- a/populus/config/web3.py
+++ b/populus/config/web3.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     is_string,

--- a/populus/contracts/backends/filesystem.py
+++ b/populus/contracts/backends/filesystem.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import json
 import os

--- a/populus/contracts/backends/project.py
+++ b/populus/contracts/backends/project.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     to_dict,

--- a/populus/contracts/backends/testing.py
+++ b/populus/contracts/backends/testing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from populus.utils.contracts import (
     is_test_contract,

--- a/populus/contracts/contract.py
+++ b/populus/contracts/contract.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     to_dict,

--- a/populus/utils/base58.py
+++ b/populus/utils/base58.py
@@ -9,7 +9,7 @@ ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 
 if sys.version_info.major == 2:
-    iseq = lambda s: map(ord, s)  # noqa: E731
+    iseq = lambda s: list(map(ord, s))  # noqa: E731
     bseq = lambda s: ''.join(map(chr, s))  # noqa: E731
     buffer = lambda s: s  # noqa: E731
 else:

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 import logging

--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 

--- a/populus/utils/logging.py
+++ b/populus/utils/logging.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/utils/six/__init__.py
+++ b/populus/utils/six/__init__.py
@@ -1,15 +1,5 @@
-import sys
-
-
-if sys.version_info.major == 2:
-    from .six_py2 import (
-        queue,
-        configparser,
-        parse,
-    )
-else:
-    from .six_py3 import (  # noqa: #401
-        queue,
-        configparser,
-        parse,
-    )
+from .six_py3 import (  # noqa: #401
+    queue,
+    configparser,
+    parse,
+)

--- a/populus/utils/six/six_py2.py
+++ b/populus/utils/six/six_py2.py
@@ -1,3 +1,0 @@
-import queue as queue  # noqa: #401
-import configparser as configparser # noqa: #401
-import urllib.parse as parse  # noqa: F401

--- a/populus/utils/six/six_py2.py
+++ b/populus/utils/six/six_py2.py
@@ -1,3 +1,3 @@
-import Queue as queue  # noqa: #401
-import ConfigParser as configparser # noqa: #401
-import urlparse as parse  # noqa: F401
+import queue as queue  # noqa: #401
+import configparser as configparser # noqa: #401
+import urllib.parse as parse  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}
+    py{34,35,36}
     flake8
 
 [flake8]
@@ -16,7 +16,6 @@ passenv =
     TRAVIS_BUILD_DIR
 deps=-r{toxinidir}/requirements-dev.txt
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

Python 2 Support ends. Additionally some dependencies no longer work for Python 2.7.

### How was it fixed?

Use 2to3 tool to apply a set of fixers to convert code into Python3 specific syntax, remove Python 2.7 from tox, Travis and setup.py

#### Cute Animal Picture

![](https://www.reefguard.pl/wp-content/uploads/2016/10/Fotolia_110923756_XL-600x600.jpg)
