### PR TITLE
drop support for python27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,50 +11,36 @@ env:
 matrix:
   include:
     # Solc 0.4.13
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.13 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.14
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.14 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.15
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.15 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.16
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.16 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.17
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.17 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.18
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"
       env: SOLC_VERSION=v0.4.18 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     # Solc 0.4.19
-    - python: "2.7"
-      env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py27"
     - python: "3.4"
       env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py34"
     - python: "3.5"

--- a/populus/api/deploy.py
+++ b/populus/api/deploy.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 import time

--- a/populus/chain/base.py
+++ b/populus/chain/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from pylru import lrucache
 

--- a/populus/chain/geth.py
+++ b/populus/chain/geth.py
@@ -47,7 +47,7 @@ class LoggedDevGethProcess(LoggingMixin, DevGethProcess):
             chain_name,
             'stderr',
         )
-        super(LoggedDevGethProcess, self).__init__(
+        super().__init__(
             overrides=overrides,
             chain_name=chain_name,
             base_dir=blockchains_dir,
@@ -58,14 +58,14 @@ class LoggedDevGethProcess(LoggingMixin, DevGethProcess):
 
 class LoggedTestnetGethProccess(LoggingMixin, TestnetGethProcess):
     def __init__(self, project_dir, geth_kwargs):
-        super(LoggedTestnetGethProccess, self).__init__(
+        super().__init__(
             geth_kwargs=geth_kwargs,
         )
 
 
 class LoggedMainnetGethProcess(LoggingMixin, LiveGethProcess):
     def __init__(self, project_dir, geth_kwargs):
-        super(LoggedMainnetGethProcess, self).__init__(
+        super().__init__(
             geth_kwargs=geth_kwargs,
             stdout_logfile_path=get_geth_logfile_path(
                 project_dir,
@@ -94,7 +94,7 @@ class BaseGethChain(BaseChain):
         )
         warnings.warn(warn_msg, DeprecationWarning)
         warnings.resetwarnings()
-        super(BaseGethChain, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def initialize_chain(self):
         # context manager shenanigans
@@ -102,7 +102,7 @@ class BaseGethChain(BaseChain):
         self.geth = self.get_geth_process_instance()
 
     def get_web3_config(self):
-        base_config = super(BaseGethChain, self).get_web3_config()
+        base_config = super().get_web3_config()
         config = copy.deepcopy(base_config)
         if not config.get('provider.settings'):
             if issubclass(base_config.provider_class, IPCProvider):

--- a/populus/chain/geth.py
+++ b/populus/chain/geth.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import warnings

--- a/populus/chain/testrpc.py
+++ b/populus/chain/testrpc.py
@@ -14,7 +14,7 @@ class TestRPCChain(BaseChain):
     rpc_port = None
 
     def get_web3_config(self):
-        base_config = super(TestRPCChain, self).get_web3_config()
+        base_config = super().get_web3_config()
         config = copy.deepcopy(base_config)
         config['provider.settings.port'] = self.rpc_port
         return config

--- a/populus/cli/config_cmd.py
+++ b/populus/cli/config_cmd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/compilation/__init__.py
+++ b/populus/compilation/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 import logging

--- a/populus/compilation/backends/solc_auto.py
+++ b/populus/compilation/backends/solc_auto.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from semantic_version import (
     Spec,

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import pprint
 import warnings

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -143,7 +143,7 @@ class SolcCombinedJSONBackend(BaseCompilerBackend):
         warn_msg = 'Support for solc <0.4.11 will be dropped in the next populus release'
         warnings.warn(warn_msg, DeprecationWarning)
 
-        super(SolcCombinedJSONBackend, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         self.logger.debug("Import remappings: %s", import_remappings)

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -116,7 +116,7 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
                 "versions >=0.4.11.  The SolcCombinedJSONBackend should be used "
                 "for all versions <=0.4.8"
             )
-        super(SolcStandardJSONBackend, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         self.logger.debug("Import remappings: %s", import_remappings)

--- a/populus/compilation/backends/vyper.py
+++ b/populus/compilation/backends/vyper.py
@@ -12,7 +12,7 @@ class VyperBackend(BaseCompilerBackend):
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         try:
-            from .vyper import compiler
+            from vyper import compiler
         except ImportError:
             raise ImportError(
                 'vyper needs to be installed to use VyperBackend' +

--- a/populus/compilation/backends/vyper.py
+++ b/populus/compilation/backends/vyper.py
@@ -12,7 +12,7 @@ class VyperBackend(BaseCompilerBackend):
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):
         try:
-            from vyper import compiler
+            from .vyper import compiler
         except ImportError:
             raise ImportError(
                 'vyper needs to be installed to use VyperBackend' +

--- a/populus/config/backend.py
+++ b/populus/config/backend.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from populus.utils.module_loading import (
     import_string,

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -141,7 +141,7 @@ class Config(object):
     def __bool__(self):
         return bool(self._wrapped)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.__bool__()
 
     def __len__(self):

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -141,7 +141,7 @@ class Config(object):
     def __bool__(self):
         return bool(self._wrapped)
 
-    def __bool__(self):
+    def __nonzero__(self):
         return self.__bool__()
 
     def __len__(self):

--- a/populus/config/compiler.py
+++ b/populus/config/compiler.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     is_string,

--- a/populus/config/upgrade/__init__.py
+++ b/populus/config/upgrade/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 import enum
 import pprint
 

--- a/populus/config/upgrade/v1.py
+++ b/populus/config/upgrade/v1.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v2.py
+++ b/populus/config/upgrade/v2.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v3.py
+++ b/populus/config/upgrade/v3.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import itertools

--- a/populus/config/upgrade/v4.py
+++ b/populus/config/upgrade/v4.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import itertools

--- a/populus/config/upgrade/v5.py
+++ b/populus/config/upgrade/v5.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 import pprint

--- a/populus/config/upgrade/v6.py
+++ b/populus/config/upgrade/v6.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 

--- a/populus/config/upgrade/v7.py
+++ b/populus/config/upgrade/v7.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import copy
 

--- a/populus/config/web3.py
+++ b/populus/config/web3.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     is_string,

--- a/populus/contracts/backends/filesystem.py
+++ b/populus/contracts/backends/filesystem.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import json
 import os

--- a/populus/contracts/backends/project.py
+++ b/populus/contracts/backends/project.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     to_dict,

--- a/populus/contracts/backends/testing.py
+++ b/populus/contracts/backends/testing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from populus.utils.contracts import (
     is_test_contract,

--- a/populus/contracts/contract.py
+++ b/populus/contracts/contract.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from eth_utils import (
     to_dict,

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pytest
 
 from populus.project import Project
@@ -17,10 +16,6 @@ from populus.utils.json import (
 from populus.config.helpers import (
     get_json_config_file_path,
 )
-
-
-if sys.version_info.major == 2:
-    FileNotFoundError = OSError
 
 
 def pytest_addoption(parser):

--- a/populus/project.py
+++ b/populus/project.py
@@ -1,7 +1,6 @@
 import copy
 import itertools
 import os
-import sys
 
 from eth_utils import (
     to_tuple,
@@ -49,10 +48,6 @@ from populus.config.helpers import (
 from populus.utils.testing import (
     get_tests_dir,
 )
-
-
-if sys.version_info.major == 2:
-    FileNotFoundError = OSError
 
 
 class Project(object):

--- a/populus/utils/base58.py
+++ b/populus/utils/base58.py
@@ -9,7 +9,7 @@ ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 
 if sys.version_info.major == 2:
-    iseq = lambda s: map(ord, s)  # noqa: E731
+    iseq = lambda s: list(map(ord, s))  # noqa: E731
     bseq = lambda s: ''.join(map(chr, s))  # noqa: E731
     buffer = lambda s: s  # noqa: E731
 else:

--- a/populus/utils/base58.py
+++ b/populus/utils/base58.py
@@ -1,21 +1,13 @@
 """
 Lifted from the base58 package.
 """
-import sys
-
-
 # 58 character alphabet used
 ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 
-if sys.version_info.major == 2:
-    iseq = lambda s: list(map(ord, s))  # noqa: E731
-    bseq = lambda s: ''.join(map(chr, s))  # noqa: E731
-    buffer = lambda s: s  # noqa: E731
-else:
-    iseq = lambda s: s  # noqa: E731
-    bseq = bytes  # noqa: E731
-    buffer = lambda s: s.buffer  # noqa: E731
+iseq = lambda s: s  # noqa: E731
+bseq = bytes  # noqa: E731
+buffer = lambda s: s.buffer  # noqa: E731
 
 
 def b58encode(v):

--- a/populus/utils/chains.py
+++ b/populus/utils/chains.py
@@ -1,5 +1,6 @@
 import os
 import re
+from urllib import parse
 
 from eth_utils import (
     add_0x_prefix,
@@ -9,9 +10,6 @@ from eth_utils import (
 
 from .filesystem import (
     normpath,
-)
-from .six import (
-    parse,
 )
 
 

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 import logging

--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import itertools
 

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -4,7 +4,6 @@ import fnmatch
 import functools
 import os
 import shutil
-import sys
 import tempfile as _tempfile
 
 from eth_utils import (
@@ -12,10 +11,6 @@ from eth_utils import (
     is_string,
     is_list_like,
 )
-
-
-if sys.version_info.major == 2:
-    FileNotFoundError = OSError
 
 
 def ensure_path_exists(dir_path):

--- a/populus/utils/logging.py
+++ b/populus/utils/logging.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import logging
 

--- a/populus/utils/six/__init__.py
+++ b/populus/utils/six/__init__.py
@@ -1,15 +1,5 @@
-import sys
-
-
-if sys.version_info.major == 2:
-    from .six_py2 import (
-        queue,
-        configparser,
-        parse,
-    )
-else:
-    from .six_py3 import (  # noqa: #401
-        queue,
-        configparser,
-        parse,
-    )
+from .six_py3 import (  # noqa: #401
+    queue,
+    configparser,
+    parse,
+)

--- a/populus/utils/six/__init__.py
+++ b/populus/utils/six/__init__.py
@@ -1,5 +1,0 @@
-from .six_py3 import (  # noqa: #401
-    queue,
-    configparser,
-    parse,
-)

--- a/populus/utils/six/six_py2.py
+++ b/populus/utils/six/six_py2.py
@@ -1,3 +1,0 @@
-import queue as queue  # noqa: #401
-import configparser as configparser # noqa: #401
-import urllib.parse as parse  # noqa: F401

--- a/populus/utils/six/six_py2.py
+++ b/populus/utils/six/six_py2.py
@@ -1,3 +1,3 @@
-import Queue as queue  # noqa: #401
-import ConfigParser as configparser # noqa: #401
-import urlparse as parse  # noqa: F401
+import queue as queue  # noqa: #401
+import configparser as configparser # noqa: #401
+import urllib.parse as parse  # noqa: F401

--- a/populus/utils/six/six_py3.py
+++ b/populus/utils/six/six_py3.py
@@ -1,3 +1,0 @@
-import queue  # noqa: F401
-import configparser  # noqa: F401
-from urllib import parse  # noqa: F401

--- a/populus/utils/string.py
+++ b/populus/utils/string.py
@@ -1,7 +1,4 @@
-import sys
-
 from eth_utils import (
-    force_bytes,
     force_text,
 )
 
@@ -9,11 +6,7 @@ from eth_utils import (
 def normalize_class_name(value):
     """
     For `type()` calls:
-    * Python 2 wants `str`
     * Python 3.4 wants `str`
     * Python 3.5 doesn't care.
     """
-    if sys.version_info.major == 2:
-        return force_bytes(value)
-    else:
-        return force_text(value)
+    return force_text(value)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     include_package_data=True,
     py_modules=['populus'],
     setup_requires=['setuptools-markdown'],
+    python_requires='>=3.4,<4',
     install_requires=[
         "anyconfig>=0.7.0",
         "click>=6.6",

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tests/observer-utils/test_watchdog_based_observer.py
+++ b/tests/observer-utils/test_watchdog_based_observer.py
@@ -1,10 +1,8 @@
 import os
+import queue
 
 from populus.utils.filesystem import (
     ensure_file_exists,
-)
-from populus.utils.six import (
-    queue,
 )
 from populus.utils.observers import DirWatcher
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}
+    py{34,35,36}
     flake8
 
 [flake8]
@@ -16,7 +16,6 @@ passenv =
     TRAVIS_BUILD_DIR
 deps=-r{toxinidir}/requirements-dev.txt
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

replaces #466. Some changes on top of work done by @cryptomental in #466. I have cherry-picked their commits. 
closes #469 
closes #433 
### How was it fixed?
- dropped support for `python2.7`
- dropped six module which was no longer needed.
- pinned python version in `setup.py`
- added new style super calls

#### Cute Animal Picture

![](https://peepeth.s3-us-west-1.amazonaws.com/images/peep_pics/BZE1b12n/large.JPG?1524850164)
