### PR TITLE
[WIP] Normalize Import Remapping Paths - Fixes #318

### DIFF
--- a/populus/compilation/__init__.py
+++ b/populus/compilation/__init__.py
@@ -7,6 +7,7 @@ import os
 from populus.utils.compile import (
     validate_compiled_contracts,
     post_process_compiled_contracts,
+    process_import_remappings,
 )
 from populus.utils.functional import (
     get_duplicates,
@@ -49,7 +50,9 @@ def compile_project_contracts(project):
 
     base_compiled_contracts = compiler_backend.get_compiled_contracts(
         source_file_paths=all_source_paths,
-        import_remappings=project.config.get('compilation.import_remappings'),
+        import_remappings=process_import_remappings(
+            project.config.get('compilation.import_remappings')
+        ),
     )
     compiled_contracts = post_process_compiled_contracts(base_compiled_contracts)
     validate_compiled_contracts(compiled_contracts)

--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -71,6 +71,20 @@ def get_compiled_contracts_asset_path(build_asset_dir):
     )
     return compiled_contracts_asset_path
 
+def normalize_import_remapping(import_remapping):
+    source_path, _, rest = import_remapping.rpartition(':')
+    import_path, _, remapped_path = rest.partition('=')
+    abs_remapped_path = os.path.abspath(remapped_path)
+    if import_remapping.endswith(os.path.sep):
+        abs_remapped_path += os.path.sep
+    if source_path:
+        return '{0}:{1}={2}'.format(source_path, import_path, abs_remapped_path)
+    else:
+        return '{0}={1}'.format(import_path, abs_remapped_path)
+
+def process_import_remappings(import_remappings):
+    return [normalize_import_remapping(remapping) for remapping in import_remappings]
+
 
 def write_compiled_sources(compiled_contracts_asset_path, compiled_sources):
     logger = logging.getLogger('populus.compilation.write_compiled_sources')

--- a/tests/compile-utils/test_normalize_import_remappings.py
+++ b/tests/compile-utils/test_normalize_import_remappings.py
@@ -1,0 +1,33 @@
+import os
+
+from populus.utils.compile import process_import_remappings
+
+beginning_paths = {
+    'import-path-in-source/={0}'.format('actual-path/'),
+    'import-path-in-source={0}'.format('actual-path'),
+    'source-file.sol:import-path-in-source/={0}'.format('actual-path/'),
+    'source-file.sol:import-path-in-source={0}'.format('actual-path'),
+}
+
+abs_path = os.path.abspath('actual-path')
+
+expected_paths = {
+    'import-path-in-source/={0}'.format(abs_path + '/'),
+    'import-path-in-source={0}'.format(abs_path),
+    'source-file.sol:import-path-in-source/={0}'.format(abs_path + '/'),
+    'source-file.sol:import-path-in-source={0}'.format(abs_path),
+}
+
+final_paths = process_import_remappings(beginning_paths)
+
+def print_paths(list, name):
+    print(name)
+    for path in list:
+        print('\t ' + path)
+
+print_paths(beginning_paths, 'beginning_paths')
+print_paths(expected_paths, 'expected_paths')
+print_paths(final_paths, 'final_paths')
+
+
+assert set(final_paths) == set(expected_paths)

--- a/tests/compile-utils/test_normalize_import_remappings.py
+++ b/tests/compile-utils/test_normalize_import_remappings.py
@@ -20,14 +20,4 @@ expected_paths = {
 
 final_paths = process_import_remappings(beginning_paths)
 
-def print_paths(list, name):
-    print(name)
-    for path in list:
-        print('\t ' + path)
-
-print_paths(beginning_paths, 'beginning_paths')
-print_paths(expected_paths, 'expected_paths')
-print_paths(final_paths, 'final_paths')
-
-
 assert set(final_paths) == set(expected_paths)


### PR DESCRIPTION
### What was wrong?
Including files by relative path from outside the populus project directory did not work.


### How was it fixed?
All import remappings are first normalized to the absolute path.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/4149002/42553658-536a2c0a-84a7-11e8-8b51-90b634711a80.png)

