### PR TITLE
updated eth-tester version to 0.1.0-beta.32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "anyconfig>=0.7.0",
         "click>=6.6",
         "contextlib2>=0.5.4",
-        "eth-tester[py-evm]==0.1.0-beta.26",
+        "eth-tester[py-evm]==0.1.0-beta.32",
         "eth-utils>=1.0.3,<2.0.0",
         "jsonschema>=2.5.1",
         "py-geth>=1.9.0",


### PR DESCRIPTION
### What was wrong?
`eth-tester` was pinned to `0.1.0-beta.26`.
`status` in transaction receipts were missing. These were added in a later version

### How was it fixed?

updated eth-tester version to 0.1.0-beta.31


#### Cute Animal Picture

 ![](https://www.50-best.com/images/cute_animal_pictures/cute_little_rat.jpg)
