### PR TITLE
[WIP]install vyper from vyper and setup extras_require['dev']

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,6 @@ matrix:
       env: SOLC_VERSION=v0.4.24 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py35"
     - python: "3.6"
       env: SOLC_VERSION=v0.4.24 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py36"
-    # Vyper
-    - python: "3.6"
-      env: SOLC_VERSION=v0.4.19 GETH_VERSION=v1.6.6 TOX_POSARGS="-e py36" INSTALL_VYPER="true"
     # Linting
     - python: "3.5"
       env: TOX_POSARGS="-e flake8"
@@ -96,8 +93,6 @@ install:
   - if [ -n "$GETH_VERSION" ]; then travis_retry pip install "py-geth>=1.9.0"; fi
   - if [ -n "$GETH_VERSION" ]; then python -m geth.install $GETH_VERSION; fi
   - if [ -n "$GETH_VERSION" ]; then export GETH_BINARY="$GETH_BASE_INSTALL_PATH/geth-$GETH_VERSION/bin/geth"; fi
-  # install vyper if necessary.
-  - if [ -n "$INSTALL_VYPER" ]; then pip install https://github.com/ethereum/vyper/archive/master.zip; fi
   # package
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
-tox>=1.8.0
-hypothesis>=3.4.2
-pytest-xdist==1.18.1
-flake8==3.5.0
-bumpversion==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,21 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
+extras_require = {
+    "vyper": ["vyper==0.1.0b1"],
+    "dev": [
+        "tox>=1.8.0",
+        "hypothesis>=3.31.2",
+        "pytest>=3.5.0,<4",
+        "flake8==3.5.0",
+        "bumpversion",
+    ]
+}
+
+extras_require['dev'] = (
+    extras_require['vyper'] +
+    extras_require['dev']
+)
 
 setup(
     name='populus',
@@ -34,6 +49,7 @@ setup(
         "watchdog>=0.8.3",
         "web3>=4.4.0,<5",
     ],
+    extras_require=extras_require,
     license="MIT",
     zip_safe=False,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ passenv =
     SOLC_BINARY
     GETH_BINARY
     TRAVIS_BUILD_DIR
-deps=-r{toxinidir}/requirements-dev.txt
+deps =
+    .[dev]
 basepython =
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?
vyper tests weren't running in CI


### How was it fixed?
(Not fixed really. Expect `python3.5` tests to fail as vyper is strictly `python>=3.6`.)

Now that `vyper` is available on `pypi`, install it from `pypi`. 
Also install removed `requiremnets-dev.txt` and added it it to `extras_require['dev']`

 ### TODO
- [ ] install vyper only for python3.6 tests

#### Cute Animal Picture

![](https://peepeth.s3-us-west-1.amazonaws.com/images/peep_pics/kYhnJdSd/medium.jpeg?1522887873)
