### PR TITLE
Use new vyper compile_codes interface.

### DIFF
--- a/docs/viper_support.rst
+++ b/docs/viper_support.rst
@@ -14,15 +14,21 @@ Vyper requires Python 3.6 or above.
 Installation
 ------------
 
-To install the compiler:
 
+For vyper relase version use:
+
+.. code-block:: shell
+
+   pip install vyper
+
+For latest vyper development version use:
 
 .. code-block:: shell
 
    pip install https://github.com/ethereum/vyper/archive/master.zip
 
 
-You will see the `vyper` binary is now installed.
+You will see the `vyper` binary is now avialable to use.
 
 
 .. code-block:: shell


### PR DESCRIPTION
### What was wrong?
The latest vyper changed the `compile` interface (partly because it's reserver keyword, partly beause multi-file support was weak).


### How was it fixed?

- Just used the new vyper.compile_codes() function ;)
- Also added a note in the docs about releases of vyper.

#### Cute Animal Picture
![](https://dobg410y77ikx.cloudfront.net/uploads/2018/03/Maine-Coon_02.jpg)